### PR TITLE
feat: postal code validation

### DIFF
--- a/library/src/actions/postalCode/index.ts
+++ b/library/src/actions/postalCode/index.ts
@@ -1,0 +1,1 @@
+export * from './postalCode.ts';

--- a/library/src/actions/postalCode/postalCode.test-d.ts
+++ b/library/src/actions/postalCode/postalCode.test-d.ts
@@ -1,0 +1,52 @@
+import { describe, expectTypeOf, test } from 'vitest';
+import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
+import {
+  type CountryCode,
+  postalCode,
+  type PostalCodeAction,
+  type PostalCodeIssue,
+} from './postalCode.ts';
+
+describe('postalCode', () => {
+  describe('should return action object', () => {
+    test('with undefined message', () => {
+      type Action = PostalCodeAction<string, CountryCode, undefined>;
+      expectTypeOf(
+        postalCode<string, CountryCode>('JP')
+      ).toEqualTypeOf<Action>();
+      expectTypeOf(
+        postalCode<string, CountryCode>('JP')
+      ).toEqualTypeOf<Action>();
+    });
+
+    test('with string message', () => {
+      expectTypeOf(
+        postalCode<string, CountryCode, 'message'>('JP', 'message')
+      ).toEqualTypeOf<PostalCodeAction<string, CountryCode, 'message'>>();
+    });
+
+    test('with function message', () => {
+      expectTypeOf(
+        postalCode<string, CountryCode, () => string>('JP', () => 'message')
+      ).toEqualTypeOf<PostalCodeAction<string, CountryCode, () => string>>();
+    });
+  });
+
+  describe('should infer correct types', () => {
+    type Action = PostalCodeAction<string, CountryCode, undefined>;
+
+    test('of input', () => {
+      expectTypeOf<InferInput<Action>>().toEqualTypeOf<string>();
+    });
+
+    test('of output', () => {
+      expectTypeOf<InferOutput<Action>>().toEqualTypeOf<string>();
+    });
+
+    test('of issue', () => {
+      expectTypeOf<InferIssue<Action>>().toEqualTypeOf<
+        PostalCodeIssue<string, CountryCode>
+      >();
+    });
+  });
+});

--- a/library/src/actions/postalCode/postalCode.test.ts
+++ b/library/src/actions/postalCode/postalCode.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, test } from 'vitest';
+import type { StringIssue } from '../../schemas/index.ts';
+import { expectActionIssue, expectNoActionIssue } from '../../vitest/index.ts';
+import {
+  type CountryCode,
+  postalCode,
+  type PostalCodeAction,
+  type PostalCodeIssue,
+} from './postalCode.ts';
+
+describe('postalCode', () => {
+  describe('should return action object', () => {
+    const baseAction: Omit<
+      PostalCodeAction<string, CountryCode, never>,
+      'message'
+    > = {
+      kind: 'validation',
+      type: 'postal_code',
+      reference: postalCode,
+      expects: null,
+      requirement: expect.any(Function),
+      async: false,
+      '~run': expect.any(Function),
+    };
+
+    test('with undefined message', () => {
+      const action: PostalCodeAction<string, CountryCode, undefined> = {
+        ...baseAction,
+        message: undefined,
+      };
+      expect(postalCode('JP')).toStrictEqual(action);
+      expect(postalCode('JP', undefined)).toStrictEqual(action);
+    });
+
+    test('with string message', () => {
+      expect(postalCode('JP', 'message')).toStrictEqual({
+        ...baseAction,
+        message: 'message',
+      } satisfies PostalCodeAction<string, CountryCode, string>);
+    });
+
+    test('with function message', () => {
+      const message = () => 'message';
+      expect(postalCode('JP', message)).toStrictEqual({
+        ...baseAction,
+        message,
+      } satisfies PostalCodeAction<string, CountryCode, typeof message>);
+    });
+  });
+
+  describe('should return dataset without issues for JP', () => {
+    const action = postalCode('JP');
+
+    test('for untyped inputs', () => {
+      const issues: [StringIssue] = [
+        {
+          kind: 'schema',
+          type: 'string',
+          input: null,
+          expected: 'string',
+          received: 'null',
+          message: 'message',
+        },
+      ];
+      expect(
+        action['~run']({ typed: false, value: null, issues }, {})
+      ).toStrictEqual({
+        typed: false,
+        value: null,
+        issues,
+      });
+    });
+
+    test('valid postal codes', () => {
+      expectNoActionIssue(action, ['012-3456', '0123456']);
+    });
+  });
+
+  describe('should return dataset without issues for US', () => {
+    const action = postalCode('US');
+
+    test('for untyped inputs', () => {
+      const issues: [StringIssue] = [
+        {
+          kind: 'schema',
+          type: 'string',
+          input: null,
+          expected: 'string',
+          received: 'null',
+          message: 'message',
+        },
+      ];
+      expect(
+        action['~run']({ typed: false, value: null, issues }, {})
+      ).toStrictEqual({
+        typed: false,
+        value: null,
+        issues,
+      });
+    });
+
+    test('for United States', () => {
+      expectNoActionIssue(action, ['01234-5678', '01234']);
+    });
+  });
+
+  describe('should return dataset with issues for JP', () => {
+    const action = postalCode('JP', 'message');
+    const baseIssue: Omit<
+      PostalCodeIssue<string, string>,
+      'input' | 'received'
+    > = {
+      kind: 'validation',
+      type: 'postal_code',
+      expected: null,
+      message: 'message',
+      requirement: expect.any(Function),
+    };
+
+    test('invalid postal codes', () => {
+      expectActionIssue(action, baseIssue, [
+        '012345', // too short
+        '012-34567', // too short
+        '0123-4567', // too short
+        '01234567', // too long
+        '012-345678', // too long
+        '012345678', // too long
+        '01234 5678', // with space
+        '', // empty
+        '\n', // lf
+        ' ', // space
+        '　', // space
+        '\t', // tab
+      ]);
+    });
+  });
+
+  describe('should return dataset with issues for US', () => {
+    const action = postalCode('US', 'message');
+    const baseIssue: Omit<
+      PostalCodeIssue<string, string>,
+      'input' | 'received'
+    > = {
+      kind: 'validation',
+      type: 'postal_code',
+      expected: null,
+      message: 'message',
+      requirement: expect.any(Function),
+    };
+
+    test('invalid postal codes', () => {
+      expectActionIssue(action, baseIssue, [
+        '0123', // too short
+        '0123-45678', // too short
+        '012345-678', // too short
+        '012345', // too long
+        '01234-56789', // too long
+        '0123456-789', // too long
+        '01234 5678', // with space
+        '', // empty
+        '\n', // lf
+        ' ', // space
+        '　', // space
+        '\t', // tab
+      ]);
+    });
+  });
+});

--- a/library/src/actions/postalCode/postalCode.ts
+++ b/library/src/actions/postalCode/postalCode.ts
@@ -116,7 +116,7 @@ export function postalCode<TInput extends string, CountryCode>(
 export function postalCode<
   TInput extends string,
   CountryCode,
-  const TMessage extends
+  TMessage extends
     | ErrorMessage<PostalCodeIssue<TInput, CountryCode>>
     | undefined,
 >(

--- a/library/src/actions/postalCode/postalCode.ts
+++ b/library/src/actions/postalCode/postalCode.ts
@@ -1,0 +1,154 @@
+import type {
+  BaseIssue,
+  BaseValidation,
+  ErrorMessage,
+} from '../../types/index.ts';
+import { _addIssue } from '../../utils/index.ts';
+
+/**
+ * Type to determine postal code format by country.
+ * Country code is based on [ISO 3166-1 alpha-2](https://ja.wikipedia.org/wiki/ISO_3166-1).
+ *
+ */
+const COUNTRY_CODE = {
+  JP: 'JP',
+  US: 'US',
+} as const;
+
+export type CountryCode = keyof typeof COUNTRY_CODE;
+
+/**
+ * get postal code pattern by country code
+ *
+ * @param countryCode Country code which based on [ISO 3166-1 alpha-2](https://ja.wikipedia.org/wiki/ISO_3166-1)
+ *
+ * @returns postal code pattern
+ */
+const getPostalCodePattern = (countryCode: CountryCode): RegExp => {
+  switch (countryCode) {
+    case COUNTRY_CODE.JP:
+      return /^\d{3}-?\d{4}$/u;
+    case COUNTRY_CODE.US:
+      return /^\d{5}(?:-\d{4})?$/u;
+    default:
+      throw new Error(`Unsupported country code: ${countryCode}`);
+  }
+};
+
+/**
+ * Postal Code issue interface.
+ */
+export interface PostalCodeIssue<TInput extends string, CountryCode>
+  extends BaseIssue<TInput> {
+  /**
+   * The issue kind.
+   */
+  readonly kind: 'validation';
+  /**
+   * The issue type.
+   */
+  readonly type: 'postal_code';
+  /**
+   * The expected property.
+   */
+  readonly expected: null;
+  /**
+   * The received property.
+   */
+  readonly received: `"${string}"`;
+  /**
+   * The validation function.
+   */
+  readonly requirement: (input: string, countryCode: CountryCode) => boolean;
+}
+
+/**
+ * Postal Code action interface.
+ */
+export interface PostalCodeAction<
+  TInput extends string,
+  CountryCode,
+  TMessage extends
+    | ErrorMessage<PostalCodeIssue<TInput, CountryCode>>
+    | undefined,
+> extends BaseValidation<TInput, TInput, PostalCodeIssue<TInput, CountryCode>> {
+  /**
+   * The action type.
+   */
+  readonly type: 'postal_code';
+  /**
+   * The action reference.
+   */
+  readonly reference: typeof postalCode;
+  /**
+   * The expected property.
+   */
+  readonly expects: null;
+  /**
+   * The validation function.
+   */
+  readonly requirement: (input: string, countryCode: CountryCode) => boolean;
+  /**
+   * The error message.
+   */
+  readonly message: TMessage;
+}
+
+/**
+ * Creates a postal code validation action.
+ *
+ * @param countryCode Country code which based on [ISO 3166-1 alpha-2](https://ja.wikipedia.org/wiki/ISO_3166-1)
+ *
+ * @returns A postal code action.
+ */
+export function postalCode<TInput extends string, CountryCode>(
+  countryCode: CountryCode
+): PostalCodeAction<TInput, CountryCode, undefined>;
+
+/**
+ * Creates a postal code validation action.
+ *
+ * @param countryCode Country code which based on [ISO 3166-1 alpha-2](https://ja.wikipedia.org/wiki/ISO_3166-1)
+ * @param message The error message.
+ *
+ * @returns A postal code action.
+ */
+export function postalCode<
+  TInput extends string,
+  CountryCode,
+  const TMessage extends
+    | ErrorMessage<PostalCodeIssue<TInput, CountryCode>>
+    | undefined,
+>(
+  countryCode: CountryCode,
+  message: TMessage
+): PostalCodeAction<TInput, CountryCode, TMessage>;
+
+// @__NO_SIDE_EFFECTS__
+export function postalCode(
+  countryCode: CountryCode,
+  message?: ErrorMessage<PostalCodeIssue<string, CountryCode>>
+): PostalCodeAction<
+  string,
+  CountryCode,
+  ErrorMessage<PostalCodeIssue<string, CountryCode>> | undefined
+> {
+  return {
+    kind: 'validation',
+    type: 'postal_code',
+    reference: postalCode,
+    async: false,
+    expects: null,
+    requirement(input, countryCode) {
+      const pattern = getPostalCodePattern(countryCode);
+      return pattern.test(input);
+    },
+    message,
+    '~run'(dataset, config) {
+      if (dataset.typed && !this.requirement(dataset.value, countryCode)) {
+        _addIssue(this, 'postal code', dataset, config);
+      }
+      return dataset;
+    },
+  };
+}

--- a/website/src/routes/api/(actions)/postalCode/index.mdx
+++ b/website/src/routes/api/(actions)/postalCode/index.mdx
@@ -1,0 +1,9 @@
+---
+title: postalCode
+contributors:
+  - ysknsid25
+---
+
+# postalCode
+
+> The content of this page is not yet ready. Until then just use the [source code](https://github.com/fabian-hiller/valibot/blob/main/library/src/actions/postalCode/postalCode.ts).

--- a/website/src/routes/api/(schemas)/string/index.mdx
+++ b/website/src/routes/api/(schemas)/string/index.mdx
@@ -194,6 +194,7 @@ The following APIs can be combined with `string`.
     'notValues',
     'notWords',
     'octal',
+    'postalCode',
     'rawCheck',
     'rawTransform',
     'readonly',

--- a/website/src/routes/api/menu.md
+++ b/website/src/routes/api/menu.md
@@ -33,6 +33,7 @@
 - [objectWithRest](/api/objectWithRest/)
 - [optional](/api/optional/)
 - [picklist](/api/picklist/)
+- [postalCode](/api/postalCode/)
 - [promise](/api/promise/)
 - [record](/api/record/)
 - [set](/api/set/)

--- a/website/src/routes/guides/(main-concepts)/pipelines/index.mdx
+++ b/website/src/routes/guides/(main-concepts)/pipelines/index.mdx
@@ -111,6 +111,7 @@ Pipeline validation actions examine the input and, if the input does not meet a 
     'notWords',
     'octal',
     'partialCheck',
+    'postalCode',
     'rawCheck',
     'regex',
     'rfcEmail',


### PR DESCRIPTION
Japanese often implement postal code checks. But all are self-implemented.

 Even Zod does not provide it as standard.

Therefore, we thought that the addition of postal code validation could be a factor that would give valibot an advantage in Japan.

In addition, although this time we have prepared for Japan and the U.S., it is possible to extend it by adding the country code to CountryCode and the regular expression pattern corresponding to the country code to getPostalCodePattern.