### PR TITLE
feat: use namespaces to export "internal" types that are used in exported signatures

### DIFF
--- a/library/eslint.config.js
+++ b/library/eslint.config.js
@@ -83,6 +83,7 @@ export default tseslint.config(
       '@typescript-eslint/no-non-null-assertion': 'off',
       '@typescript-eslint/consistent-indexed-object-style': 'off',
       '@typescript-eslint/no-inferrable-types': 'off',
+      '@typescript-eslint/no-namespace': 'off',
 
       // Imports
       'no-duplicate-imports': 'off',

--- a/library/src/actions/args/args.ts
+++ b/library/src/actions/args/args.ts
@@ -18,18 +18,20 @@ import type {
 } from '../../types/index.ts';
 import { ValiError } from '../../utils/index.ts';
 
-/**
- * Schema type.
- */
-type Schema =
-  | LooseTupleSchema<TupleItems, ErrorMessage<LooseTupleIssue> | undefined>
-  | StrictTupleSchema<TupleItems, ErrorMessage<StrictTupleIssue> | undefined>
-  | TupleSchema<TupleItems, ErrorMessage<TupleIssue> | undefined>
-  | TupleWithRestSchema<
-      TupleItems,
-      BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<TupleWithRestIssue> | undefined
-    >;
+export namespace args {
+  /**
+   * Schema type.
+   */
+  export type Schema =
+    | LooseTupleSchema<TupleItems, ErrorMessage<LooseTupleIssue> | undefined>
+    | StrictTupleSchema<TupleItems, ErrorMessage<StrictTupleIssue> | undefined>
+    | TupleSchema<TupleItems, ErrorMessage<TupleIssue> | undefined>
+    | TupleWithRestSchema<
+        TupleItems,
+        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<TupleWithRestIssue> | undefined
+      >;
+}
 
 /**
  * Args action type.
@@ -37,7 +39,7 @@ type Schema =
 export interface ArgsAction<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TInput extends (...args: any[]) => unknown,
-  TSchema extends Schema,
+  TSchema extends args.Schema,
 > extends BaseTransformation<
     TInput,
     (...args: InferInput<TSchema>) => ReturnType<TInput>,
@@ -67,13 +69,13 @@ export interface ArgsAction<
 export function args<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TInput extends (...args: any[]) => unknown,
-  TSchema extends Schema,
+  TSchema extends args.Schema,
 >(schema: TSchema): ArgsAction<TInput, TSchema>;
 
 // @__NO_SIDE_EFFECTS__
 export function args(
-  schema: Schema
-): ArgsAction<(...args: unknown[]) => unknown, Schema> {
+  schema: args.Schema
+): ArgsAction<(...args: unknown[]) => unknown, args.Schema> {
   return {
     kind: 'transformation',
     type: 'args',

--- a/library/src/actions/args/argsAsync.ts
+++ b/library/src/actions/args/argsAsync.ts
@@ -25,33 +25,35 @@ import type {
 } from '../../types/index.ts';
 import { ValiError } from '../../utils/index.ts';
 
-/**
- * Schema type.
- */
-type Schema =
-  | LooseTupleSchema<TupleItems, ErrorMessage<LooseTupleIssue> | undefined>
-  | LooseTupleSchemaAsync<
-      TupleItemsAsync,
-      ErrorMessage<LooseTupleIssue> | undefined
-    >
-  | StrictTupleSchema<TupleItems, ErrorMessage<StrictTupleIssue> | undefined>
-  | StrictTupleSchemaAsync<
-      TupleItemsAsync,
-      ErrorMessage<StrictTupleIssue> | undefined
-    >
-  | TupleSchema<TupleItems, ErrorMessage<TupleIssue> | undefined>
-  | TupleSchemaAsync<TupleItemsAsync, ErrorMessage<TupleIssue> | undefined>
-  | TupleWithRestSchema<
-      TupleItems,
-      BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<TupleWithRestIssue> | undefined
-    >
-  | TupleWithRestSchemaAsync<
-      TupleItemsAsync,
-      | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-      | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<TupleWithRestIssue> | undefined
-    >;
+export namespace argsAsync {
+  /**
+   * Schema type.
+   */
+  export type Schema =
+    | LooseTupleSchema<TupleItems, ErrorMessage<LooseTupleIssue> | undefined>
+    | LooseTupleSchemaAsync<
+        TupleItemsAsync,
+        ErrorMessage<LooseTupleIssue> | undefined
+      >
+    | StrictTupleSchema<TupleItems, ErrorMessage<StrictTupleIssue> | undefined>
+    | StrictTupleSchemaAsync<
+        TupleItemsAsync,
+        ErrorMessage<StrictTupleIssue> | undefined
+      >
+    | TupleSchema<TupleItems, ErrorMessage<TupleIssue> | undefined>
+    | TupleSchemaAsync<TupleItemsAsync, ErrorMessage<TupleIssue> | undefined>
+    | TupleWithRestSchema<
+        TupleItems,
+        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<TupleWithRestIssue> | undefined
+      >
+    | TupleWithRestSchemaAsync<
+        TupleItemsAsync,
+        | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+        | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<TupleWithRestIssue> | undefined
+      >;
+}
 
 /**
  * Args action async type.
@@ -59,7 +61,7 @@ type Schema =
 export interface ArgsActionAsync<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TInput extends (...args: any[]) => unknown,
-  TSchema extends Schema,
+  TSchema extends argsAsync.Schema,
 > extends BaseTransformation<
     TInput,
     (...args: InferInput<TSchema>) => Promise<Awaited<ReturnType<TInput>>>,
@@ -89,13 +91,13 @@ export interface ArgsActionAsync<
 export function argsAsync<
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   TInput extends (...args: any[]) => unknown,
-  TSchema extends Schema,
+  TSchema extends argsAsync.Schema,
 >(schema: TSchema): ArgsActionAsync<TInput, TSchema>;
 
 // @__NO_SIDE_EFFECTS__
 export function argsAsync(
-  schema: Schema
-): ArgsActionAsync<(...args: unknown[]) => unknown, Schema> {
+  schema: argsAsync.Schema
+): ArgsActionAsync<(...args: unknown[]) => unknown, argsAsync.Schema> {
   return {
     kind: 'transformation',
     type: 'args',

--- a/library/src/methods/getDescription/getDescription.ts
+++ b/library/src/methods/getDescription/getDescription.ts
@@ -9,34 +9,36 @@ import type {
 import { _getLastMetadata } from '../../utils/index.ts';
 import type { SchemaWithPipe, SchemaWithPipeAsync } from '../index.ts';
 
-/**
- * Schema type.
- */
-type Schema =
-  | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-  | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
-  | SchemaWithPipe<
-      readonly [
-        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-        ...(
-          | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
-          | DescriptionAction<unknown, string>
-        )[],
-      ]
-    >
-  | SchemaWithPipeAsync<
-      readonly [
-        (
-          | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-          | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
-        ),
-        ...(
-          | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
-          | PipeItemAsync<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
-          | DescriptionAction<unknown, string>
-        )[],
-      ]
-    >;
+export namespace getDescription {
+  /**
+   * Schema type.
+   */
+  export type Schema =
+    | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+    | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
+    | SchemaWithPipe<
+        readonly [
+          BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+          ...(
+            | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
+            | DescriptionAction<unknown, string>
+          )[],
+        ]
+      >
+    | SchemaWithPipeAsync<
+        readonly [
+          (
+            | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+            | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
+          ),
+          ...(
+            | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
+            | PipeItemAsync<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
+            | DescriptionAction<unknown, string>
+          )[],
+        ]
+      >;
+}
 
 /**
  * Returns the description of the schema.
@@ -52,6 +54,8 @@ type Schema =
  */
 // TODO: Investigate if return type can be strongly typed
 // @__NO_SIDE_EFFECTS__
-export function getDescription(schema: Schema): string | undefined {
+export function getDescription(
+  schema: getDescription.Schema
+): string | undefined {
   return _getLastMetadata(schema, 'description');
 }

--- a/library/src/methods/getMetadata/getMetadata.ts
+++ b/library/src/methods/getMetadata/getMetadata.ts
@@ -10,34 +10,36 @@ import type {
 } from '../../types/index.ts';
 import type { SchemaWithPipe, SchemaWithPipeAsync } from '../pipe/index.ts';
 
-/**
- * Schema type.
- */
-type Schema =
-  | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-  | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
-  | SchemaWithPipe<
-      readonly [
-        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-        ...(
-          | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
-          | MetadataAction<unknown, Record<string, unknown>>
-        )[],
-      ]
-    >
-  | SchemaWithPipeAsync<
-      readonly [
-        (
-          | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-          | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
-        ),
-        ...(
-          | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
-          | PipeItemAsync<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
-          | MetadataAction<unknown, Record<string, unknown>>
-        )[],
-      ]
-    >;
+export namespace getMetadata {
+  /**
+   * Schema type.
+   */
+  export type Schema =
+    | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+    | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
+    | SchemaWithPipe<
+        readonly [
+          BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+          ...(
+            | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
+            | MetadataAction<unknown, Record<string, unknown>>
+          )[],
+        ]
+      >
+    | SchemaWithPipeAsync<
+        readonly [
+          (
+            | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+            | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
+          ),
+          ...(
+            | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
+            | PipeItemAsync<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
+            | MetadataAction<unknown, Record<string, unknown>>
+          )[],
+        ]
+      >;
+}
 
 /**
  * Basic pipe item type.
@@ -74,7 +76,7 @@ type RecursiveMerge<
  *
  * @beta
  */
-export type InferMetadata<TSchema extends Schema> =
+export type InferMetadata<TSchema extends getMetadata.Schema> =
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   BaseSchema<any, any, any> extends TSchema
     ? Record<string, unknown>
@@ -101,11 +103,11 @@ export type InferMetadata<TSchema extends Schema> =
  * @beta
  */
 // @__NO_SIDE_EFFECTS__
-export function getMetadata<const TSchema extends Schema>(
+export function getMetadata<const TSchema extends getMetadata.Schema>(
   schema: TSchema
 ): InferMetadata<TSchema> {
   const result = {};
-  function depthFirstMerge(schema: Schema): void {
+  function depthFirstMerge(schema: getMetadata.Schema): void {
     if ('pipe' in schema) {
       for (const item of schema.pipe) {
         if (item.kind === 'schema' && 'pipe' in item) {

--- a/library/src/methods/getTitle/getTitle.ts
+++ b/library/src/methods/getTitle/getTitle.ts
@@ -9,35 +9,36 @@ import type {
 import { _getLastMetadata } from '../../utils/index.ts';
 import type { SchemaWithPipe, SchemaWithPipeAsync } from '../index.ts';
 
-/**
- * Schema type.
- */
-type Schema =
-  | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-  | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
-  | SchemaWithPipe<
-      readonly [
-        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-        ...(
-          | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
-          | TitleAction<unknown, string>
-        )[],
-      ]
-    >
-  | SchemaWithPipeAsync<
-      readonly [
-        (
-          | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-          | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
-        ),
-        ...(
-          | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
-          | PipeItemAsync<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
-          | TitleAction<unknown, string>
-        )[],
-      ]
-    >;
-
+export namespace getTitle {
+  /**
+   * Schema type.
+   */
+  export type Schema =
+    | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+    | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
+    | SchemaWithPipe<
+        readonly [
+          BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+          ...(
+            | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
+            | TitleAction<unknown, string>
+          )[],
+        ]
+      >
+    | SchemaWithPipeAsync<
+        readonly [
+          (
+            | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+            | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
+          ),
+          ...(
+            | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
+            | PipeItemAsync<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
+            | TitleAction<unknown, string>
+          )[],
+        ]
+      >;
+}
 /**
  * Returns the title of the schema.
  *
@@ -52,6 +53,6 @@ type Schema =
  */
 // TODO: Investigate if return type can be strongly typed
 // @__NO_SIDE_EFFECTS__
-export function getTitle(schema: Schema): string | undefined {
+export function getTitle(schema: getTitle.Schema): string | undefined {
   return _getLastMetadata(schema, 'title');
 }

--- a/library/src/methods/keyof/keyof.ts
+++ b/library/src/methods/keyof/keyof.ts
@@ -24,35 +24,43 @@ import type {
   UnionToTuple,
 } from '../../types/index.ts';
 
-/**
- * Schema type.
- */
-type Schema =
-  | LooseObjectSchema<ObjectEntries, ErrorMessage<LooseObjectIssue> | undefined>
-  | LooseObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<LooseObjectIssue> | undefined
-    >
-  | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectSchemaAsync<ObjectEntriesAsync, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectWithRestSchema<
-      ObjectEntries,
-      BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | ObjectWithRestSchemaAsync<
-      ObjectEntriesAsync,
-      BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | StrictObjectSchema<
-      ObjectEntries,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >
-  | StrictObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >;
+export namespace keyof_ {
+  /**
+   * Schema type.
+   */
+  export type Schema =
+    | LooseObjectSchema<
+        ObjectEntries,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | LooseObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
+    | ObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<ObjectIssue> | undefined
+      >
+    | ObjectWithRestSchema<
+        ObjectEntries,
+        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | ObjectWithRestSchemaAsync<
+        ObjectEntriesAsync,
+        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | StrictObjectSchema<
+        ObjectEntries,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >
+    | StrictObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >;
+}
 
 /**
  * Force tuple type.
@@ -62,7 +70,7 @@ type ForceTuple<T> = T extends [string, ...string[]] ? T : [];
 /**
  * Object keys type.
  */
-type ObjectKeys<TSchema extends Schema> = ForceTuple<
+type ObjectKeys<TSchema extends keyof_.Schema> = ForceTuple<
   UnionToTuple<keyof TSchema['entries']>
 >;
 
@@ -73,7 +81,7 @@ type ObjectKeys<TSchema extends Schema> = ForceTuple<
  *
  * @returns A picklist schema.
  */
-export function keyof<const TSchema extends Schema>(
+export function keyof_<const TSchema extends keyof_.Schema>(
   schema: TSchema
 ): PicklistSchema<ObjectKeys<TSchema>, undefined>;
 
@@ -85,8 +93,8 @@ export function keyof<const TSchema extends Schema>(
  *
  * @returns A picklist schema.
  */
-export function keyof<
-  const TSchema extends Schema,
+export function keyof_<
+  const TSchema extends keyof_.Schema,
   const TMessage extends ErrorMessage<PicklistIssue> | undefined,
 >(
   schema: TSchema,
@@ -94,9 +102,17 @@ export function keyof<
 ): PicklistSchema<ObjectKeys<TSchema>, TMessage>;
 
 // @__NO_SIDE_EFFECTS__
-export function keyof(
-  schema: Schema,
+export function keyof_(
+  schema: keyof_.Schema,
   message?: ErrorMessage<PicklistIssue>
-): PicklistSchema<ObjectKeys<Schema>, ErrorMessage<PicklistIssue> | undefined> {
-  return picklist(Object.keys(schema.entries) as ObjectKeys<Schema>, message);
+): PicklistSchema<
+  ObjectKeys<keyof_.Schema>,
+  ErrorMessage<PicklistIssue> | undefined
+> {
+  return picklist(
+    Object.keys(schema.entries) as ObjectKeys<keyof_.Schema>,
+    message
+  );
 }
+
+export { keyof_ as keyof };

--- a/library/src/methods/omit/omit.ts
+++ b/library/src/methods/omit/omit.ts
@@ -34,43 +34,51 @@ import type {
 } from '../../types/index.ts';
 import { _getStandardProps } from '../../utils/index.ts';
 
-/**
- * Schema type.
- */
-type Schema = SchemaWithoutPipe<
-  | LooseObjectSchema<ObjectEntries, ErrorMessage<LooseObjectIssue> | undefined>
-  | LooseObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<LooseObjectIssue> | undefined
-    >
-  | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectSchemaAsync<ObjectEntriesAsync, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectWithRestSchema<
-      ObjectEntries,
-      BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | ObjectWithRestSchemaAsync<
-      ObjectEntriesAsync,
-      | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-      | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | StrictObjectSchema<
-      ObjectEntries,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >
-  | StrictObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >
->;
+export namespace omit {
+  /**
+   * Schema type.
+   */
+  export type Schema = SchemaWithoutPipe<
+    | LooseObjectSchema<
+        ObjectEntries,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | LooseObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
+    | ObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<ObjectIssue> | undefined
+      >
+    | ObjectWithRestSchema<
+        ObjectEntries,
+        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | ObjectWithRestSchemaAsync<
+        ObjectEntriesAsync,
+        | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+        | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | StrictObjectSchema<
+        ObjectEntries,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >
+    | StrictObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >
+  >;
+}
 
 /**
  * Schema with omit type.
  */
 export type SchemaWithOmit<
-  TSchema extends Schema,
+  TSchema extends omit.Schema,
   TKeys extends ObjectKeys<TSchema>,
 > = TSchema extends
   | ObjectSchema<infer TEntries, ErrorMessage<ObjectIssue> | undefined>
@@ -465,7 +473,7 @@ export type SchemaWithOmit<
  */
 // @__NO_SIDE_EFFECTS__
 export function omit<
-  const TSchema extends Schema,
+  const TSchema extends omit.Schema,
   const TKeys extends ObjectKeys<TSchema>,
 >(schema: TSchema, keys: TKeys): SchemaWithOmit<TSchema, TKeys> {
   // Create modified object entries

--- a/library/src/methods/partial/partial.ts
+++ b/library/src/methods/partial/partial.ts
@@ -29,22 +29,27 @@ import type {
 } from '../../types/index.ts';
 import { _getStandardProps } from '../../utils/index.ts';
 
-/**
- * Schema type.
- */
-type Schema = SchemaWithoutPipe<
-  | LooseObjectSchema<ObjectEntries, ErrorMessage<LooseObjectIssue> | undefined>
-  | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectWithRestSchema<
-      ObjectEntries,
-      BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | StrictObjectSchema<
-      ObjectEntries,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >
->;
+export namespace partial {
+  /**
+   * Schema type.
+   */
+  export type Schema = SchemaWithoutPipe<
+    | LooseObjectSchema<
+        ObjectEntries,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
+    | ObjectWithRestSchema<
+        ObjectEntries,
+        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | StrictObjectSchema<
+        ObjectEntries,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >
+  >;
+}
 
 /**
  * Partial entries type.
@@ -64,7 +69,7 @@ type PartialEntries<
  * Schema with partial type.
  */
 export type SchemaWithPartial<
-  TSchema extends Schema,
+  TSchema extends partial.Schema,
   TKeys extends ObjectKeys<TSchema> | undefined,
 > = TSchema extends
   | ObjectSchema<infer TEntries, ErrorMessage<ObjectIssue> | undefined>
@@ -248,7 +253,7 @@ export type SchemaWithPartial<
  *
  * @returns An object schema.
  */
-export function partial<const TSchema extends Schema>(
+export function partial<const TSchema extends partial.Schema>(
   schema: TSchema
 ): SchemaWithPartial<TSchema, undefined>;
 
@@ -262,17 +267,17 @@ export function partial<const TSchema extends Schema>(
  * @returns An object schema.
  */
 export function partial<
-  const TSchema extends Schema,
+  const TSchema extends partial.Schema,
   const TKeys extends ObjectKeys<TSchema>,
 >(schema: TSchema, keys: TKeys): SchemaWithPartial<TSchema, TKeys>;
 
 // @__NO_SIDE_EFFECTS__
 export function partial(
-  schema: Schema,
-  keys?: ObjectKeys<Schema>
-): SchemaWithPartial<Schema, ObjectKeys<Schema> | undefined> {
+  schema: partial.Schema,
+  keys?: ObjectKeys<partial.Schema>
+): SchemaWithPartial<partial.Schema, ObjectKeys<partial.Schema> | undefined> {
   // Create modified object entries
-  const entries: PartialEntries<ObjectEntries, ObjectKeys<Schema>> = {};
+  const entries: PartialEntries<ObjectEntries, ObjectKeys<partial.Schema>> = {};
   for (const key in schema.entries) {
     // @ts-expect-error
     entries[key] =

--- a/library/src/methods/partial/partialAsync.ts
+++ b/library/src/methods/partial/partialAsync.ts
@@ -30,26 +30,31 @@ import type {
 } from '../../types/index.ts';
 import { _getStandardProps } from '../../utils/index.ts';
 
-/**
- * Schema type.
- */
-type Schema = SchemaWithoutPipe<
-  | LooseObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<LooseObjectIssue> | undefined
-    >
-  | ObjectSchemaAsync<ObjectEntriesAsync, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectWithRestSchemaAsync<
-      ObjectEntriesAsync,
-      | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-      | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | StrictObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >
->;
+export namespace partialAsync {
+  /**
+   * Schema type.
+   */
+  export type Schema = SchemaWithoutPipe<
+    | LooseObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | ObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<ObjectIssue> | undefined
+      >
+    | ObjectWithRestSchemaAsync<
+        ObjectEntriesAsync,
+        | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+        | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | StrictObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >
+  >;
+}
 
 /**
  * Partial entries type.
@@ -69,7 +74,7 @@ type PartialEntries<
  * Schema with partial type.
  */
 export type SchemaWithPartialAsync<
-  TSchema extends Schema,
+  TSchema extends partialAsync.Schema,
   TKeys extends ObjectKeys<TSchema> | undefined,
 > = TSchema extends
   | ObjectSchemaAsync<infer TEntries, ErrorMessage<ObjectIssue> | undefined>
@@ -259,7 +264,7 @@ export type SchemaWithPartialAsync<
  *
  * @returns An object schema.
  */
-export function partialAsync<const TSchema extends Schema>(
+export function partialAsync<const TSchema extends partialAsync.Schema>(
   schema: TSchema
 ): SchemaWithPartialAsync<TSchema, undefined>;
 
@@ -273,17 +278,23 @@ export function partialAsync<const TSchema extends Schema>(
  * @returns An object schema.
  */
 export function partialAsync<
-  const TSchema extends Schema,
+  const TSchema extends partialAsync.Schema,
   const TKeys extends ObjectKeys<TSchema>,
 >(schema: TSchema, keys: TKeys): SchemaWithPartialAsync<TSchema, TKeys>;
 
 // @__NO_SIDE_EFFECTS__
 export function partialAsync(
-  schema: Schema,
-  keys?: ObjectKeys<Schema>
-): SchemaWithPartialAsync<Schema, ObjectKeys<Schema> | undefined> {
+  schema: partialAsync.Schema,
+  keys?: ObjectKeys<partialAsync.Schema>
+): SchemaWithPartialAsync<
+  partialAsync.Schema,
+  ObjectKeys<partialAsync.Schema> | undefined
+> {
   // Create modified object entries
-  const entries: PartialEntries<ObjectEntriesAsync, ObjectKeys<Schema>> = {};
+  const entries: PartialEntries<
+    ObjectEntriesAsync,
+    ObjectKeys<partialAsync.Schema>
+  > = {};
   for (const key in schema.entries) {
     // @ts-expect-error
     entries[key] =

--- a/library/src/methods/pick/pick.ts
+++ b/library/src/methods/pick/pick.ts
@@ -34,43 +34,51 @@ import type {
 } from '../../types/index.ts';
 import { _getStandardProps } from '../../utils/index.ts';
 
-/**
- * The schema type.
- */
-type Schema = SchemaWithoutPipe<
-  | LooseObjectSchema<ObjectEntries, ErrorMessage<LooseObjectIssue> | undefined>
-  | LooseObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<LooseObjectIssue> | undefined
-    >
-  | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectSchemaAsync<ObjectEntriesAsync, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectWithRestSchema<
-      ObjectEntries,
-      BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | ObjectWithRestSchemaAsync<
-      ObjectEntriesAsync,
-      | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-      | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | StrictObjectSchema<
-      ObjectEntries,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >
-  | StrictObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >
->;
+export namespace pick {
+  /**
+   * The schema type.
+   */
+  export type Schema = SchemaWithoutPipe<
+    | LooseObjectSchema<
+        ObjectEntries,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | LooseObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
+    | ObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<ObjectIssue> | undefined
+      >
+    | ObjectWithRestSchema<
+        ObjectEntries,
+        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | ObjectWithRestSchemaAsync<
+        ObjectEntriesAsync,
+        | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+        | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | StrictObjectSchema<
+        ObjectEntries,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >
+    | StrictObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >
+  >;
+}
 
 /**
  * Schema with pick type.
  */
 export type SchemaWithPick<
-  TSchema extends Schema,
+  TSchema extends pick.Schema,
   TKeys extends ObjectKeys<TSchema>,
 > = TSchema extends
   | ObjectSchema<infer TEntries, ErrorMessage<ObjectIssue> | undefined>
@@ -465,7 +473,7 @@ export type SchemaWithPick<
  */
 // @__NO_SIDE_EFFECTS__
 export function pick<
-  const TSchema extends Schema,
+  const TSchema extends pick.Schema,
   const TKeys extends ObjectKeys<TSchema>,
 >(schema: TSchema, keys: TKeys): SchemaWithPick<TSchema, TKeys> {
   // Create modified object entries

--- a/library/src/methods/required/required.ts
+++ b/library/src/methods/required/required.ts
@@ -30,22 +30,27 @@ import type {
 } from '../../types/index.ts';
 import { _getStandardProps } from '../../utils/index.ts';
 
-/**
- * Schema type.
- */
-type Schema = SchemaWithoutPipe<
-  | LooseObjectSchema<ObjectEntries, ErrorMessage<LooseObjectIssue> | undefined>
-  | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectWithRestSchema<
-      ObjectEntries,
-      BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | StrictObjectSchema<
-      ObjectEntries,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >
->;
+export namespace required {
+  /**
+   * Schema type.
+   */
+  export type Schema = SchemaWithoutPipe<
+    | LooseObjectSchema<
+        ObjectEntries,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
+    | ObjectWithRestSchema<
+        ObjectEntries,
+        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | StrictObjectSchema<
+        ObjectEntries,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >
+  >;
+}
 
 /**
  * Required entries type.
@@ -66,7 +71,7 @@ type RequiredEntries<
  * Schema with required type.
  */
 export type SchemaWithRequired<
-  TSchema extends Schema,
+  TSchema extends required.Schema,
   TKeys extends ObjectKeys<TSchema> | undefined,
   TMessage extends ErrorMessage<NonOptionalIssue> | undefined,
 > = TSchema extends
@@ -257,7 +262,7 @@ export type SchemaWithRequired<
  */
 // @ts-expect-error FIXME: TypeScript incorrectly claims that the overload
 // signature is not compatible with the implementation signature
-export function required<const TSchema extends Schema>(
+export function required<const TSchema extends required.Schema>(
   schema: TSchema
 ): SchemaWithRequired<TSchema, undefined, undefined>;
 
@@ -270,7 +275,7 @@ export function required<const TSchema extends Schema>(
  * @returns An object schema.
  */
 export function required<
-  const TSchema extends Schema,
+  const TSchema extends required.Schema,
   const TMessage extends ErrorMessage<NonOptionalIssue> | undefined,
 >(
   schema: TSchema,
@@ -287,7 +292,7 @@ export function required<
  * @returns An object schema.
  */
 export function required<
-  const TSchema extends Schema,
+  const TSchema extends required.Schema,
   const TKeys extends ObjectKeys<TSchema>,
 >(schema: TSchema, keys: TKeys): SchemaWithRequired<TSchema, TKeys, undefined>;
 
@@ -302,7 +307,7 @@ export function required<
  * @returns An object schema.
  */
 export function required<
-  const TSchema extends Schema,
+  const TSchema extends required.Schema,
   const TKeys extends ObjectKeys<TSchema>,
   const TMessage extends ErrorMessage<NonOptionalIssue> | undefined,
 >(
@@ -313,12 +318,12 @@ export function required<
 
 // @__NO_SIDE_EFFECTS__
 export function required(
-  schema: Schema,
-  arg2?: ErrorMessage<NonOptionalIssue> | ObjectKeys<Schema>,
+  schema: required.Schema,
+  arg2?: ErrorMessage<NonOptionalIssue> | ObjectKeys<required.Schema>,
   arg3?: ErrorMessage<NonOptionalIssue>
 ): SchemaWithRequired<
-  Schema,
-  ObjectKeys<Schema> | undefined,
+  required.Schema,
+  ObjectKeys<required.Schema> | undefined,
   ErrorMessage<NonOptionalIssue> | undefined
 > {
   // Get keys and message from arguments
@@ -330,7 +335,7 @@ export function required(
   // Create modified object entries
   const entries: RequiredEntries<
     ObjectEntries,
-    ObjectKeys<Schema>,
+    ObjectKeys<required.Schema>,
     ErrorMessage<NonOptionalIssue> | undefined
   > = {};
   for (const key in schema.entries) {

--- a/library/src/methods/required/requiredAsync.ts
+++ b/library/src/methods/required/requiredAsync.ts
@@ -31,26 +31,31 @@ import type {
 } from '../../types/index.ts';
 import { _getStandardProps } from '../../utils/index.ts';
 
-/**
- * Schema type.
- */
-type Schema = SchemaWithoutPipe<
-  | LooseObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<LooseObjectIssue> | undefined
-    >
-  | ObjectSchemaAsync<ObjectEntriesAsync, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectWithRestSchemaAsync<
-      ObjectEntriesAsync,
-      | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-      | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | StrictObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >
->;
+export namespace requiredAsync {
+  /**
+   * Schema type.
+   */
+  export type Schema = SchemaWithoutPipe<
+    | LooseObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | ObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<ObjectIssue> | undefined
+      >
+    | ObjectWithRestSchemaAsync<
+        ObjectEntriesAsync,
+        | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+        | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | StrictObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >
+  >;
+}
 
 /**
  * Required entries type.
@@ -71,7 +76,7 @@ type RequiredEntries<
  * Schema with required type.
  */
 export type SchemaWithRequiredAsync<
-  TSchema extends Schema,
+  TSchema extends requiredAsync.Schema,
   TKeys extends ObjectKeys<TSchema> | undefined,
   TMessage extends ErrorMessage<NonOptionalIssue> | undefined,
 > = TSchema extends
@@ -281,7 +286,7 @@ export function requiredAsync<const TSchema extends Schema>(
  * @returns An object schema.
  */
 export function requiredAsync<
-  const TSchema extends Schema,
+  const TSchema extends requiredAsync.Schema,
   const TMessage extends ErrorMessage<NonOptionalIssue> | undefined,
 >(
   schema: TSchema,
@@ -298,7 +303,7 @@ export function requiredAsync<
  * @returns An object schema.
  */
 export function requiredAsync<
-  const TSchema extends Schema,
+  const TSchema extends requiredAsync.Schema,
   const TKeys extends ObjectKeys<TSchema>,
 >(
   schema: TSchema,
@@ -316,7 +321,7 @@ export function requiredAsync<
  * @returns An object schema.
  */
 export function requiredAsync<
-  const TSchema extends Schema,
+  const TSchema extends requiredAsync.Schema,
   const TKeys extends ObjectKeys<TSchema>,
   const TMessage extends ErrorMessage<NonOptionalIssue> | undefined,
 >(
@@ -327,12 +332,12 @@ export function requiredAsync<
 
 // @__NO_SIDE_EFFECTS__
 export function requiredAsync(
-  schema: Schema,
-  arg2?: ErrorMessage<NonOptionalIssue> | ObjectKeys<Schema>,
+  schema: requiredAsync.Schema,
+  arg2?: ErrorMessage<NonOptionalIssue> | ObjectKeys<requiredAsync.Schema>,
   arg3?: ErrorMessage<NonOptionalIssue>
 ): SchemaWithRequiredAsync<
-  Schema,
-  ObjectKeys<Schema> | undefined,
+  requiredAsync.Schema,
+  ObjectKeys<requiredAsync.Schema> | undefined,
   ErrorMessage<NonOptionalIssue> | undefined
 > {
   // Get keys and message from arguments
@@ -344,7 +349,7 @@ export function requiredAsync(
   // Create modified object entries
   const entries: RequiredEntries<
     ObjectEntriesAsync,
-    ObjectKeys<Schema>,
+    ObjectKeys<requiredAsync.Schema>,
     ErrorMessage<NonOptionalIssue> | undefined
   > = {};
   for (const key in schema.entries) {

--- a/library/src/utils/_getLastMetadata/_getLastMetadata.ts
+++ b/library/src/utils/_getLastMetadata/_getLastMetadata.ts
@@ -11,39 +11,41 @@ import type {
   PipeItemAsync,
 } from '../../types/index.ts';
 
-/**
- * Metadata action type.
- */
-type MetadataAction =
-  | TitleAction<unknown, string>
-  | DescriptionAction<unknown, string>;
+export namespace _getLastMetadata {
+  /**
+   * Metadata action type.
+   */
+  type MetadataAction =
+    | TitleAction<unknown, string>
+    | DescriptionAction<unknown, string>;
 
-/**
- * Schema type.
- */
-type Schema =
-  | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-  | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
-  | SchemaWithPipe<
-      readonly [
-        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        ...(PipeItem<any, unknown, BaseIssue<unknown>> | MetadataAction)[],
-      ]
-    >
-  | SchemaWithPipeAsync<
-      readonly [
-        (
-          | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-          | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
-        ),
-        ...(
-          | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
-          | PipeItemAsync<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
-          | MetadataAction
-        )[],
-      ]
-    >;
+  /**
+   * Schema type.
+   */
+  export type Schema =
+    | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+    | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
+    | SchemaWithPipe<
+        readonly [
+          BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          ...(PipeItem<any, unknown, BaseIssue<unknown>> | MetadataAction)[],
+        ]
+      >
+    | SchemaWithPipeAsync<
+        readonly [
+          (
+            | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+            | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>
+          ),
+          ...(
+            | PipeItem<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
+            | PipeItemAsync<any, unknown, BaseIssue<unknown>> // eslint-disable-line @typescript-eslint/no-explicit-any
+            | MetadataAction
+          )[],
+        ]
+      >;
+}
 
 /**
  * Returns the last top-level value of a given metadata type from a schema
@@ -58,11 +60,11 @@ type Schema =
  */
 // @__NO_SIDE_EFFECTS__
 export function _getLastMetadata(
-  schema: Schema,
+  schema: _getLastMetadata.Schema,
   type: 'title' | 'description'
 ): string | undefined {
   if ('pipe' in schema) {
-    const nestedSchemas: Schema[] = [];
+    const nestedSchemas: _getLastMetadata.Schema[] = [];
     for (let index = schema.pipe.length - 1; index >= 0; index--) {
       const item = schema.pipe[index];
       if (item.kind === 'schema' && 'pipe' in item) {

--- a/library/src/utils/entriesFromObjects/entriesFromObjects.ts
+++ b/library/src/utils/entriesFromObjects/entriesFromObjects.ts
@@ -23,56 +23,76 @@ import type {
   Prettify,
 } from '../../types/index.ts';
 
-/**
- * Schema type.
- */
-type Schema =
-  | LooseObjectSchema<ObjectEntries, ErrorMessage<LooseObjectIssue> | undefined>
-  | LooseObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<LooseObjectIssue> | undefined
-    >
-  | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectSchemaAsync<ObjectEntriesAsync, ErrorMessage<ObjectIssue> | undefined>
-  | ObjectWithRestSchema<
-      ObjectEntries,
-      BaseSchema<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | ObjectWithRestSchemaAsync<
-      ObjectEntriesAsync,
-      | BaseSchema<unknown, unknown, BaseIssue<unknown>>
-      | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
-      ErrorMessage<ObjectWithRestIssue> | undefined
-    >
-  | StrictObjectSchema<
-      ObjectEntries,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >
-  | StrictObjectSchemaAsync<
-      ObjectEntriesAsync,
-      ErrorMessage<StrictObjectIssue> | undefined
-    >;
+export namespace entriesFromObjects {
+  /**
+   * Schema type.
+   */
+  export type Schema =
+    | LooseObjectSchema<
+        ObjectEntries,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | LooseObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<LooseObjectIssue> | undefined
+      >
+    | ObjectSchema<ObjectEntries, ErrorMessage<ObjectIssue> | undefined>
+    | ObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<ObjectIssue> | undefined
+      >
+    | ObjectWithRestSchema<
+        ObjectEntries,
+        BaseSchema<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | ObjectWithRestSchemaAsync<
+        ObjectEntriesAsync,
+        | BaseSchema<unknown, unknown, BaseIssue<unknown>>
+        | BaseSchemaAsync<unknown, unknown, BaseIssue<unknown>>,
+        ErrorMessage<ObjectWithRestIssue> | undefined
+      >
+    | StrictObjectSchema<
+        ObjectEntries,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >
+    | StrictObjectSchemaAsync<
+        ObjectEntriesAsync,
+        ErrorMessage<StrictObjectIssue> | undefined
+      >;
+}
 
 /**
  * Recursive merge type.
  */
-type RecursiveMerge<TSchemas extends readonly [Schema, ...Schema[]]> =
-  TSchemas extends readonly [infer TFirstSchema extends Schema]
-    ? TFirstSchema['entries']
-    : TSchemas extends readonly [
-          infer TFirstSchema extends Schema,
-          ...infer TRestSchemas extends readonly [Schema, ...Schema[]],
-        ]
-      ? Merge<TFirstSchema['entries'], RecursiveMerge<TRestSchemas>>
-      : never;
+type RecursiveMerge<
+  TSchemas extends readonly [
+    entriesFromObjects.Schema,
+    ...entriesFromObjects.Schema[],
+  ],
+> = TSchemas extends readonly [
+  infer TFirstSchema extends entriesFromObjects.Schema,
+]
+  ? TFirstSchema['entries']
+  : TSchemas extends readonly [
+        infer TFirstSchema extends entriesFromObjects.Schema,
+        ...infer TRestSchemas extends readonly [
+          entriesFromObjects.Schema,
+          ...entriesFromObjects.Schema[],
+        ],
+      ]
+    ? Merge<TFirstSchema['entries'], RecursiveMerge<TRestSchemas>>
+    : never;
 
 /**
  * Merged entries types.
  */
-type MergedEntries<TSchemas extends readonly [Schema, ...Schema[]]> = Prettify<
-  RecursiveMerge<TSchemas>
->;
+type MergedEntries<
+  TSchemas extends readonly [
+    entriesFromObjects.Schema,
+    ...entriesFromObjects.Schema[],
+  ],
+> = Prettify<RecursiveMerge<TSchemas>>;
 
 /**
  * Creates a new object entries definition from existing object schemas.
@@ -82,13 +102,16 @@ type MergedEntries<TSchemas extends readonly [Schema, ...Schema[]]> = Prettify<
  * @returns The object entries from the schemas.
  */
 export function entriesFromObjects<
-  const TSchemas extends readonly [Schema, ...Schema[]],
+  const TSchemas extends readonly [
+    entriesFromObjects.Schema,
+    ...entriesFromObjects.Schema[],
+  ],
 >(schemas: TSchemas): MergedEntries<TSchemas>;
 
 // @__NO_SIDE_EFFECTS__
 export function entriesFromObjects(
-  schemas: [Schema, ...Schema[]]
-): MergedEntries<[Schema, ...Schema[]]> {
+  schemas: [entriesFromObjects.Schema, ...entriesFromObjects.Schema[]]
+): MergedEntries<[entriesFromObjects.Schema, ...entriesFromObjects.Schema[]]> {
   const entries = {};
   for (const schema of schemas) {
     Object.assign(entries, schema.entries);

--- a/packages/to-json-schema/eslint.config.js
+++ b/packages/to-json-schema/eslint.config.js
@@ -63,6 +63,7 @@ export default tseslint.config(
       // TypeScript
       '@typescript-eslint/ban-ts-comment': 'off',
       '@typescript-eslint/no-non-null-assertion': 'off',
+      '@typescript-eslint/no-namespace': 'off',
 
       // Imports
       'no-duplicate-imports': 'off',

--- a/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
+++ b/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
@@ -4,107 +4,123 @@ import type { ConversionConfig, ConversionContext } from '../../type.ts';
 import { addError, handleError } from '../../utils/index.ts';
 import { convertAction } from '../convertAction/index.ts';
 
-/**
- * Schema type.
- */
-type Schema =
-  | v.AnySchema
-  | v.UnknownSchema
-  | v.NullableSchema<
-      v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
-      v.Default<v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>, null>
-    >
-  | v.NullishSchema<
-      v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
-      v.Default<
+export namespace convertSchema {
+  /**
+   * Schema type.
+   */
+  export type Schema =
+    | v.AnySchema
+    | v.UnknownSchema
+    | v.NullableSchema<
         v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
-        null | undefined
+        v.Default<v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>, null>
       >
-    >
-  | v.NullSchema<v.ErrorMessage<v.NullIssue> | undefined>
-  | v.StringSchema<v.ErrorMessage<v.StringIssue> | undefined>
-  | v.BooleanSchema<v.ErrorMessage<v.BooleanIssue> | undefined>
-  | v.NumberSchema<v.ErrorMessage<v.NumberIssue> | undefined>
-  | v.LiteralSchema<v.Literal, v.ErrorMessage<v.LiteralIssue> | undefined>
-  | v.PicklistSchema<
-      v.PicklistOptions,
-      v.ErrorMessage<v.PicklistIssue> | undefined
-    >
-  | v.EnumSchema<v.Enum, v.ErrorMessage<v.EnumIssue> | undefined>
-  | v.VariantSchema<
-      string,
-      v.VariantOptions<string>,
-      v.ErrorMessage<v.VariantIssue> | undefined
-    >
-  | v.UnionSchema<
-      v.UnionOptions,
-      v.ErrorMessage<v.UnionIssue<v.BaseIssue<unknown>>> | undefined
-    >
-  | v.IntersectSchema<
-      v.IntersectOptions,
-      v.ErrorMessage<v.IntersectIssue> | undefined
-    >
-  | v.ObjectSchema<v.ObjectEntries, v.ErrorMessage<v.ObjectIssue> | undefined>
-  | v.ObjectWithRestSchema<
-      v.ObjectEntries,
-      v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
-      v.ErrorMessage<v.ObjectWithRestIssue> | undefined
-    >
-  | v.ExactOptionalSchema<
-      v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
-      v.Default<v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>, undefined>
-    >
-  | v.OptionalSchema<
-      v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
-      v.Default<v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>, undefined>
-    >
-  | v.UndefinedableSchema<
-      v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
-      v.Default<v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>, undefined>
-    >
-  | v.StrictObjectSchema<
-      v.ObjectEntries,
-      v.ErrorMessage<v.StrictObjectIssue> | undefined
-    >
-  | v.LooseObjectSchema<
-      v.ObjectEntries,
-      v.ErrorMessage<v.LooseObjectIssue> | undefined
-    >
-  | v.RecordSchema<
-      v.BaseSchema<string, string | number | symbol, v.BaseIssue<unknown>>,
-      v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
-      v.ErrorMessage<v.RecordIssue> | undefined
-    >
-  | v.TupleSchema<v.TupleItems, v.ErrorMessage<v.TupleIssue> | undefined>
-  | v.TupleWithRestSchema<
-      v.TupleItems,
-      v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
-      v.ErrorMessage<v.TupleWithRestIssue> | undefined
-    >
-  | v.LooseTupleSchema<
-      v.TupleItems,
-      v.ErrorMessage<v.LooseTupleIssue> | undefined
-    >
-  | v.StrictTupleSchema<
-      v.TupleItems,
-      v.ErrorMessage<v.StrictTupleIssue> | undefined
-    >
-  | v.ArraySchema<
-      v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
-      v.ErrorMessage<v.ArrayIssue> | undefined
-    >
-  | v.LazySchema<v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>>;
+    | v.NullishSchema<
+        v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+        v.Default<
+          v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+          null | undefined
+        >
+      >
+    | v.NullSchema<v.ErrorMessage<v.NullIssue> | undefined>
+    | v.StringSchema<v.ErrorMessage<v.StringIssue> | undefined>
+    | v.BooleanSchema<v.ErrorMessage<v.BooleanIssue> | undefined>
+    | v.NumberSchema<v.ErrorMessage<v.NumberIssue> | undefined>
+    | v.LiteralSchema<v.Literal, v.ErrorMessage<v.LiteralIssue> | undefined>
+    | v.PicklistSchema<
+        v.PicklistOptions,
+        v.ErrorMessage<v.PicklistIssue> | undefined
+      >
+    | v.EnumSchema<v.Enum, v.ErrorMessage<v.EnumIssue> | undefined>
+    | v.VariantSchema<
+        string,
+        v.VariantOptions<string>,
+        v.ErrorMessage<v.VariantIssue> | undefined
+      >
+    | v.UnionSchema<
+        v.UnionOptions,
+        v.ErrorMessage<v.UnionIssue<v.BaseIssue<unknown>>> | undefined
+      >
+    | v.IntersectSchema<
+        v.IntersectOptions,
+        v.ErrorMessage<v.IntersectIssue> | undefined
+      >
+    | v.ObjectSchema<v.ObjectEntries, v.ErrorMessage<v.ObjectIssue> | undefined>
+    | v.ObjectWithRestSchema<
+        v.ObjectEntries,
+        v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+        v.ErrorMessage<v.ObjectWithRestIssue> | undefined
+      >
+    | v.ExactOptionalSchema<
+        v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+        v.Default<
+          v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+          undefined
+        >
+      >
+    | v.OptionalSchema<
+        v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+        v.Default<
+          v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+          undefined
+        >
+      >
+    | v.UndefinedableSchema<
+        v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+        v.Default<
+          v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+          undefined
+        >
+      >
+    | v.StrictObjectSchema<
+        v.ObjectEntries,
+        v.ErrorMessage<v.StrictObjectIssue> | undefined
+      >
+    | v.LooseObjectSchema<
+        v.ObjectEntries,
+        v.ErrorMessage<v.LooseObjectIssue> | undefined
+      >
+    | v.RecordSchema<
+        v.BaseSchema<string, string | number | symbol, v.BaseIssue<unknown>>,
+        v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+        v.ErrorMessage<v.RecordIssue> | undefined
+      >
+    | v.TupleSchema<v.TupleItems, v.ErrorMessage<v.TupleIssue> | undefined>
+    | v.TupleWithRestSchema<
+        v.TupleItems,
+        v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+        v.ErrorMessage<v.TupleWithRestIssue> | undefined
+      >
+    | v.LooseTupleSchema<
+        v.TupleItems,
+        v.ErrorMessage<v.LooseTupleIssue> | undefined
+      >
+    | v.StrictTupleSchema<
+        v.TupleItems,
+        v.ErrorMessage<v.StrictTupleIssue> | undefined
+      >
+    | v.ArraySchema<
+        v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+        v.ErrorMessage<v.ArrayIssue> | undefined
+      >
+    | v.LazySchema<v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>>;
+}
 
 /**
  * Pipe type.
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-type Pipe = readonly (Schema | v.PipeAction<any, any, v.BaseIssue<unknown>>)[];
+
+type Pipe = readonly (
+  | convertSchema.Schema
+  | v.PipeAction<any, any, v.BaseIssue<unknown>>
+)[];
 
 /**
  * Schema or pipe type.
  */
-type SchemaOrPipe = Schema | v.SchemaWithPipe<readonly [Schema, ...Pipe]>;
+type SchemaOrPipe =
+  | convertSchema.Schema
+  | v.SchemaWithPipe<readonly [convertSchema.Schema, ...Pipe]>;
 
 /**
  * Flattens a Valibot pipe by recursively expanding nested pipes.


### PR DESCRIPTION
Currently there's no easy way to get the type for "a schema I can pass to this method", as the Schema type for each is internal. This PR uses type-only namespaces to nest the type under the method/action itself, meaning it avoids conflicts but still allows use if needed.

 An example of where this would be useful:

```ts
import * as v from 'valibot'

export class TypedHttpClient<T extends v.partial.Schema> {
  constructor(private schema: T) {}

  get(someUrl: string, selectFields: string[]) {
    const rawData = null; // fetch data with includeFields

    const partialSchema = v.partial(this.schema);

    const output = v.parse(partialSchema, rawData);
  }
}
```