### PR TITLE
Replace Modular Forms with Formisch in validation example

### DIFF
--- a/website/src/routes/guides/(get-started)/use-cases/index.mdx
+++ b/website/src/routes/guides/(get-started)/use-cases/index.mdx
@@ -22,7 +22,7 @@ This works particularly well with a schema, compared to if/else conditions, as e
 
 A schema can also be used for form validation. Due to Valibot's small bundle size and the possibility to individualize the error messages, the library is particularly well suited for this. Also, fullstack frameworks like Next.js, Remix, and Nuxt allow the same schema to be used for validation in the browser as well as on the server, which reduces your code to the minimum.
 
-[Modular Forms](https://modularforms.dev/react/guides/validate-your-fields#schema-validation), for example, offers validation based on a schema at form and field level. In addition, the form can be made type-safe using the schema, which also enables autocompletion during development. In combination with the right framework, a fully type-safe and progressively enhanced form can be created with few lines of code and a great experience for developers and end-users.
+[Formisch](https://formisch.dev/react/guides/introduction/), for example, offers validation based on a schema at form and field level. In addition, the form can be made type-safe using the schema, which also enables autocompletion during development. In combination with the right framework, a fully type-safe and progressively enhanced form can be created with few lines of code and a great experience for developers and end-users.
 
 ## Browser state
 


### PR DESCRIPTION
Replaced the older Modular Forms with the newer, actively developed Formisch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the Modular Forms reference with `Formisch` in the use-cases guide, updating the schema validation example link to formisch.dev so the docs point to the actively maintained library.

<sup>Written for commit f1af469bda450fadb9ee5b89fbda68d78bdf970a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

