### PR TITLE
Added new blog post on dependency size and cold starts in edge runtimes 

### DIFF
--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -24,8 +24,8 @@ Here's what came out of the bundler:
 
 | Library | Raw Bundle | Gzipped |
 |---|---|---|
-| Zod 4.3.6 | 523.66 KiB | 77.44 KiB |
-| Valibot 1.3.1 | 11.92 KiB | 2.71 KiB |
+| Zod 4.3.6 | 141.43 KiB | 26.75 KiB |
+| Valibot 1.3.1 | 11.92 KiB | 2.72 KiB |
 
 Valibot's gzipped bundle is 9.8x smaller than Zod's for an identical schema.
 

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -89,7 +89,7 @@ const UserSchema = object({
 });
 ```
 
-The schemas are functionally identical. The difference is what the bundler sees. In the Zod version, the bundler can see individual exports, but shared internals like the parsing engine, error formatting, and type utilities are tightly coupled and get pulled in regardless of how little of the API you use. In the Valibot version, each import is a discrete, standalone function. There is very little shared infrastructure to drag in, so the bundler includes only what the schema actually needs." For the schema in this experiment, the bundler included only the specific validators the schema used. That's most of what ended up in the bundle.
+The schemas are functionally identical. The difference is what the bundler sees. In the Zod version, the bundler can see individual exports, but shared internals like the parsing engine, error formatting, and type utilities are tightly coupled and get pulled in regardless of how little of the API you use. In the Valibot version, each import is a discrete, standalone function. There is very little shared infrastructure to drag in, so the bundler includes only what the schema actually needs. 
 
 That's where the 9.8x comes from.
 

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -1,5 +1,5 @@
 ---
-cover: Dependency Size and Cold Starts in Edge 
+cover: Cold Starts
 title: How Dependency Size Impacts Cold Starts in Edge JavaScript Runtimes
 description: A concrete experiment comparing Valibot and Zod bundle sizes, and why a 9.8x difference matters for cold start performance on edge runtimes like Cloudflare Workers.
 published: 2026-04-25
@@ -17,16 +17,16 @@ A big part of the answer lives in your dependencies.
 
 ## The Experiment
 
-To put a concrete number on this, we built a minimal Cloudflare Worker to understand the cold start cost of our own library compared to Zod, using a single User schema covering name, email, age, and role. 
+To put a concrete number on this, we built a minimal Cloudflare Worker to understand the cold start cost of our own library compared to Zod, using a single User schema covering name, email, age, and role.
 
 We built it twice using Wrangler 4.81.1 and TypeScript, keeping everything identical except for the validation library being imported. One build used Zod and the other used Valibot. Both builds were done in production mode using Wrangler's default bundling, so minification and tree-shaking are enabled.
 
 Here's what came out of the bundler:
 
-| Library | Raw Bundle | Gzipped |
-|---|---|---|
-| Zod 4.3.6 | 141.43 KiB | 26.75 KiB |
-| Valibot 1.3.1 | 11.92 KiB | 2.72 KiB |
+| **Library**       | Raw Bundle | Gzipped   |
+| ----------------- | ---------- | --------- |
+| **Zod 4.3.6**     | 141.43 KiB | 26.75 KiB |
+| **Valibot 1.3.1** | 11.92 KiB  | 2.72 KiB  |
 
 Valibot's gzipped bundle is 9.8x smaller than Zod's for an identical schema.
 
@@ -50,47 +50,37 @@ Zod uses a class-based, chainable API. It is easy to use and has strong TypeScri
 
 Valibot is built differently. Each validator is a small standalone function. You import exactly what you need. This is a fine-grained import model. The bundler can include only the functions you use and drop the rest.
 
-For the schema in this experiment, the bundler included only the specific validators the schema used. That's most of what ended up in the bundle. 
+For the schema in this experiment, the bundler included only the specific validators the schema used. That's most of what ended up in the bundle.
 
 Here's the same User schema in both libraries:
 
-
 ```ts
 // Zod
-import * as z from "zod";
+import * as z from 'zod';
 
 const UserSchema = z.object({
   name: z.string().min(1),
   email: z.string().email(),
   age: z.number().int().min(0).max(120),
-  role: z.enum(["admin", "user", "guest"]),
+  role: z.enum(['admin', 'user', 'guest']),
 });
 ```
 
-```ts 
-// Valibot 
-import {
-  email,
-  integer,
-  maxValue,
-  minLength,
-  minValue,
-  number,
-  object,
-  picklist,
-  pipe,
-  string,
-} from "valibot";
+```ts
+// Valibot
+import * as v from 'valibot';
 
-const UserSchema = object({
-  name: pipe(string(), minLength(1)),
-  email: pipe(string(), email()),
-  age: pipe(number(), integer(), minValue(0), maxValue(120)),
-  role: picklist(["admin", "user", "guest"]),
+const UserSchema = v.object({
+  name: v.pipe(v.string(), v.minLength(1)),
+  email: v.pipe(v.string(), v.email()),
+  age: v.pipe(v.number(), v.integer(), v.minValue(0), v.maxValue(120)),
+  role: v.picklist(['admin', 'user', 'guest']),
 });
 ```
 
-The schemas are functionally identical. The difference is what the bundler sees. In the Zod version, the bundler can see individual exports, but shared internals like the parsing engine, error formatting, and type utilities are tightly coupled and get pulled in regardless of how little of the API you use. In the Valibot version, each import is a discrete, standalone function. There is very little shared infrastructure to drag in, so the bundler includes only what the schema actually needs. 
+> Using `import * as v from 'valibot'` here does not disable tree-shaking. With modern ESM bundlers, namespace imports like this are still statically analyzable, so only the specific `v.*` exports referenced by the schema are retained in the final bundle.
+
+The schemas are functionally identical. The difference is what the bundler sees. In the Zod version, the bundler can see individual exports, but shared internals like the parsing engine, error formatting, and type utilities are tightly coupled and get pulled in regardless of how little of the API you use. In the Valibot version, each import is a discrete, standalone function. There is very little shared infrastructure to drag in, so the bundler includes only what the schema actually needs.
 
 That's where the 9.8x comes from.
 
@@ -100,7 +90,7 @@ Up to this point, we've only looked at one dependency in isolation. In a real ap
 
 When a new edge instance starts, the runtime has to process that script before it can respond to a request. It does not jump straight into your handler. It first has to load the code, read through it, and run the modules so everything is ready. As that bundle gets larger, that setup step takes more work. There is simply more code to go through, and more modules that need to run before the instance is ready.
 
-You can think of it as replaying your module graph on each new instance. The larger the graph, the more work the runtime has to do before it can serve anything. A 9.8x difference in bundle size means the runtime is doing materially less work on every cold start. 
+You can think of it as replaying your module graph on each new instance. The larger the graph, the more work the runtime has to do before it can serve anything. A 9.8x difference in bundle size means the runtime is doing materially less work on every cold start.
 
 This shows up most clearly during deployments and traffic spikes, exactly when you can least afford extra latency. During a traffic spike, the platform scales out and starts more instances. In quieter periods, instances may not stay warm, so the next request has to go through that setup again. In all of these cases, the first request handled by a new instance waits for that initialization to finish.
 
@@ -121,7 +111,8 @@ Valibot works with the tools most teams are already using:
 Type inference works the same way you'd expect coming from Zod:
 
 ```ts
-import { InferOutput } from "valibot";
+import { InferOutput } from 'valibot';
+
 type User = InferOutput<typeof UserSchema>;
 ```
 

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -53,27 +53,39 @@ For the schema in this experiment, this meant importing: object, string, number,
 
 Here's the same User schema in both libraries:
 
+
 ```ts
 // Zod
-import { z } from "zod";
+import * as z from "zod";
 
 const UserSchema = z.object({
-  name: z.string(),
+  name: z.string().min(1),
   email: z.string().email(),
-  age: z.number(),
-  role: z.enum(["admin", "user"]),
+  age: z.number().int().min(0).max(120),
+  role: z.enum(["admin", "user", "guest"]),
 });
 ```
 
-```ts
-// Valibot
-import { object, string, email, number, picklist, pipe } from "valibot";
+```ts 
+// Valibot 
+import {
+  email,
+  integer,
+  maxValue,
+  minLength,
+  minValue,
+  number,
+  object,
+  picklist,
+  pipe,
+  string,
+} from "valibot";
 
 const UserSchema = object({
-  name: string(),
+  name: pipe(string(), minLength(1)),
   email: pipe(string(), email()),
-  age: number(),
-  role: picklist(["admin", "user"]),
+  age: pipe(number(), integer(), minValue(0), maxValue(120)),
+  role: picklist(["admin", "user", "guest"]),
 });
 ```
 

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -1,0 +1,124 @@
+---
+title: How Dependency Size Impacts Cold Starts in Edge JavaScript Runtimes
+description: A concrete experiment comparing Valibot and Zod bundle sizes, and why a 9.8x difference matters for cold start performance on edge runtimes like Cloudflare Workers.
+published: 2026-04-25
+authors:
+  - flySewa
+---
+
+Edge runtimes have gotten pretty good at avoiding cold starts. Between isolate reuse and smarter routing, a lot of requests never hit one at all.
+
+But cold starts still happen. During deployments, traffic spikes, and scaling events, new instances spin up from scratch. And when they do, there's a step that runs before your handler can do anything: the runtime loads your bundle, parses it, and evaluates every module in it before it can handle a request.
+
+So when you're trying to understand why latency spikes during those events, the question worth asking isn't just "how often do cold starts happen?" It's "how much work is happening inside each one?"
+
+A big part of the answer lives in your dependencies.
+
+## The Experiment
+
+To put a concrete number on this, we built a minimal Cloudflare Worker to understand the cold start cost of our own library compared to Zod, using a single User schema covering name, email, age, and role. 
+
+We built it twice using Wrangler 4.81.1 and TypeScript, keeping everything identical except for the validation library being imported. One build used Zod and the other used Valibot. Both builds were done in production mode using Wrangler's default bundling, so minification and tree-shaking are enabled.
+
+Here's what came out of the bundler:
+
+| Library | Raw Bundle | Gzipped |
+|---|---|---|
+| Zod 4.3.6 | 523.66 KiB | 77.44 KiB |
+| Valibot 1.3.1 | 11.92 KiB | 2.71 KiB |
+
+Valibot's gzipped bundle is 9.8x smaller than Zod's for an identical schema.
+
+## What This Experiment Does (and Doesn't) Show
+
+This comparison focuses on bundle size and included code, not direct cold start timing, since measuring cold start latency reliably outside of production is hard because:
+
+- Edge platforms reuse isolates aggressively
+- Cold starts depend on traffic patterns and scaling behavior
+- Platform-level metrics are often not exposed in detail
+
+So instead of simulating that imperfectly, this experiment isolates one part of the problem: how much code the runtime has to load and execute during initialization. We're using bundle size as a proxy for cold start cost. In most JavaScript runtimes, more code means more parsing work, and more modules mean more evaluation work.
+
+This applies to edge runtimes that execute ESM modules on startup, including platforms like Vercel Edge Functions and Deno Deploy.
+
+## Why the Bundle Sizes Are So Different
+
+This is where it gets interesting, because the gap is a consequence of how each library is designed.
+
+Zod uses a class-based, chainable API. It is easy to use and has strong TypeScript inference. But internally, many parts of the library are tightly connected. From the bundler's perspective, this looks like a coarse-grained import. Even if you use a small part of Zod, shared internals like parsing logic and error handling often get included together.
+
+Valibot is built differently. Each validator is a small standalone function. You import exactly what you need. This is a fine-grained import model. The bundler can include only the functions you use and drop the rest.
+
+For the schema in this experiment, this meant importing: object, string, number, and email. That's most of what ended up in the bundle.
+
+Here's the same User schema in both libraries:
+
+```ts
+// Zod
+import { z } from "zod";
+
+const UserSchema = z.object({
+  name: z.string(),
+  email: z.string().email(),
+  age: z.number(),
+  role: z.enum(["admin", "user"]),
+});
+```
+
+```ts
+// Valibot
+import { object, string, email, number, picklist, pipe } from "valibot";
+
+const UserSchema = object({
+  name: string(),
+  email: pipe(string(), email()),
+  age: number(),
+  role: picklist(["admin", "user"]),
+});
+```
+
+The schemas are functionally identical. The difference is what the bundler sees. In the Zod version, importing from "zod" is a single entry point, and the bundler can't easily tell which parts of the class hierarchy you actually touched. In the Valibot version, each import is a discrete, standalone function. The bundler eliminates everything else.
+
+That's where the 9.8x comes from.
+
+## Why This Matters for Cold Starts
+
+Up to this point, we've only looked at one dependency in isolation. In a real application, that validation library sits alongside everything else you use. Routing, authentication, database clients, logging. All of it is bundled together into a single script.
+
+When a new edge instance starts, the runtime has to process that script before it can respond to a request. It does not jump straight into your handler. It first has to load the code, read through it, and run the modules so everything is ready. As that bundle gets larger, that setup step takes more work. There is simply more code to go through, and more modules that need to run before the instance is ready.
+
+You can think of it as replaying your module graph on each new instance. The larger the graph, the more work the runtime has to do before it can serve anything. A 9.8x difference in bundle size means the runtime is doing materially less work on every cold start. 
+
+This shows up most clearly during deployments and traffic spikes, exactly when you can least afford extra latency. During a traffic spike, the platform scales out and starts more instances. In quieter periods, instances may not stay warm, so the next request has to go through that setup again. In all of these cases, the first request handled by a new instance waits for that initialization to finish.
+
+A smaller bundle does not remove cold starts, but it reduces how much work happens inside each one. In edge environments, where instances are created more often, that difference is more likely to affect response time.
+
+## Does Valibot Work With the Rest of Your Stack?
+
+A fair question before switching anything is whether you lose ecosystem coverage. The short answer is no.
+
+Valibot works with the tools most teams are already using:
+
+- **tRPC** – Valibot schemas are supported natively via the Standard Schema interface. Pass a Valibot schema directly to `.input()` without any wrapper.
+- **React Hook Form** – drop-in via `@hookform/resolvers/valibot`
+- **Hono** – supported through `@hono/valibot-validator`
+- **Conform** – official support via `@conform-to/valibot`
+
+Type inference works the same way you'd expect coming from Zod:
+
+```ts
+import { InferOutput } from "valibot";
+type User = InferOutput<typeof UserSchema>;
+```
+
+If your existing codebase is heavily Zod, migration doesn't have to be a full rewrite. Most teams move validation schema-by-schema at the edges of their system, at API boundaries, form handlers, and environment config, where the cold start impact is most direct.
+
+## Where Bundle Size Actually Matters
+
+None of this means Valibot is the right choice in every situation.
+
+If you're running long-lived services where instances stay warm for extended periods, a 9.8x bundle size difference has almost no visible impact. In those environments, Zod's more ergonomic chaining and broader ecosystem familiarity may genuinely matter more.
+
+But if you're building for edge environments like Cloudflare Workers, Vercel Edge Functions, and Deno Deploy, cold starts are closer to the request path, and initialization overhead is more likely to show up in your p99s. In those environments, choosing a smaller, more modular library reduces the amount of work done during initialization without sacrificing type safety or expressiveness.
+
+The broader principle holds too: validation libraries aren't the only place this happens. Any large dependency with poor tree-shaking characteristics can have a similar effect. It's worth auditing what actually ends up in your bundle, not just what you imported.

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -89,7 +89,7 @@ const UserSchema = object({
 });
 ```
 
-The schemas are functionally identical. The difference is what the bundler sees. In the Zod version, importing from "zod" is a single entry point, and the bundler can't easily tell which parts of the class hierarchy you actually touched. In the Valibot version, each import is a discrete, standalone function. The bundler eliminates everything else.
+The schemas are functionally identical. The difference is what the bundler sees. In the Zod version, the bundler can see individual exports, but shared internals like the parsing engine, error formatting, and type utilities are tightly coupled and get pulled in regardless of how little of the API you use. In the Valibot version, each import is a discrete, standalone function. There is very little shared infrastructure to drag in, so the bundler includes only what the schema actually needs." For the schema in this experiment, the bundler included only the specific validators the schema used. That's most of what ended up in the bundle.
 
 That's where the 9.8x comes from.
 
@@ -111,10 +111,11 @@ A fair question before switching anything is whether you lose ecosystem coverage
 
 Valibot works with the tools most teams are already using:
 
-- **tRPC** – Valibot schemas are supported natively via the Standard Schema interface. Pass a Valibot schema directly to `.input()` without any wrapper.
-- **React Hook Form** – drop-in via `@hookform/resolvers/valibot`
-- **Hono** – supported through `@hono/valibot-validator`
-- **Conform** – official support via `@conform-to/valibot`
+- [**Standard Schema**](https://standardschema.dev/) – Valibot implements the Standard Schema specification, which means it works natively with any tool that supports it without adapters or wrappers.
+- [**tRPC**](https://trpc.io/) – Pass a Valibot schema directly to `.input()` without any wrapper.
+- [**React Hook Form**](https://github.com/react-hook-form/resolvers) – drop-in via `@hookform/resolvers/valibot`
+- [**Hono**](https://github.com/honojs/middleware/tree/main/packages/valibot-validator) – supported through `@hono/valibot-validator`
+- [**Conform**](https://conform.guide/) – official support via `@conform-to/valibot`
 
 Type inference works the same way you'd expect coming from Zod:
 
@@ -134,3 +135,12 @@ If you're running long-lived services where instances stay warm for extended per
 But if you're building for edge environments like Cloudflare Workers, Vercel Edge Functions, and Deno Deploy, cold starts are closer to the request path, and initialization overhead is more likely to show up in your p99s. In those environments, choosing a smaller, more modular library reduces the amount of work done during initialization without sacrificing type safety or expressiveness.
 
 The broader principle holds too: validation libraries aren't the only place this happens. Any large dependency with poor tree-shaking characteristics can have a similar effect. It's worth auditing what actually ends up in your bundle, not just what you imported.
+
+
+
+
+
+
+
+
+

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -136,11 +136,4 @@ But if you're building for edge environments like Cloudflare Workers, Vercel Edg
 
 The broader principle holds too: validation libraries aren't the only place this happens. Any large dependency with poor tree-shaking characteristics can have a similar effect. It's worth auditing what actually ends up in your bundle, not just what you imported.
 
-
-
-
-
-
-
-
-
+If you want to run the builds yourself or adapt the setup, the full repo is [here](https://github.com/Beejay9/zod-vs-valibot).

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -1,4 +1,5 @@
 ---
+cover: Dependency Size and Cold Starts in Edge 
 title: How Dependency Size Impacts Cold Starts in Edge JavaScript Runtimes
 description: A concrete experiment comparing Valibot and Zod bundle sizes, and why a 9.8x difference matters for cold start performance on edge runtimes like Cloudflare Workers.
 published: 2026-04-25

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -49,7 +49,7 @@ Zod uses a class-based, chainable API. It is easy to use and has strong TypeScri
 
 Valibot is built differently. Each validator is a small standalone function. You import exactly what you need. This is a fine-grained import model. The bundler can include only the functions you use and drop the rest.
 
-For the schema in this experiment, this meant importing: object, string, number, and email. That's most of what ended up in the bundle.
+For the schema in this experiment, the bundler included only the specific validators the schema used. That's most of what ended up in the bundle. 
 
 Here's the same User schema in both libraries:
 

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -2,7 +2,7 @@
 cover: Cold Starts
 title: How Dependency Size Impacts Cold Starts in Edge JavaScript Runtimes
 description: A concrete experiment comparing Valibot and Zod bundle sizes, and why a 9.8x difference matters for cold start performance on edge runtimes like Cloudflare Workers.
-published: 2026-04-25
+published: 2026-05-26
 authors:
   - flySewa
 ---

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -19,7 +19,7 @@ A big part of the answer lives in your dependencies.
 
 To put a concrete number on this, we built a minimal Cloudflare Worker to understand the cold start cost of our own library compared to Zod, using a single User schema covering name, email, age, and role.
 
-We built it twice using Wrangler 4.81.1 and TypeScript, keeping everything identical except for the validation library being imported. One build used Zod and the other used Valibot. Both builds were done in production mode using Wrangler's default bundling.
+We built it twice using Wrangler 4.81.1 and TypeScript, keeping everything identical except for the validation library being imported. This comparison uses the default zod package rather than zod/mini, and focuses on baseline installs and primary APIs rather than optimized variants. One build used Zod and the other used Valibot. Both builds were done in production mode using Wrangler's default bundling.
 
 Here's what came out of the bundler:
 

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -116,7 +116,7 @@ import { InferOutput } from 'valibot';
 type User = InferOutput<typeof UserSchema>;
 ```
 
-If your existing codebase is heavily Zod, migration doesn't have to be a full rewrite. Most teams move validation schema-by-schema at the edges of their system, at API boundaries, form handlers, and environment config, where the cold start impact is most direct.
+If your existing codebase is heavily Zod, migration doesn't have to be a full rewrite. Most teams move validation schema-by-schema at the edges of their system, at API boundaries, form handlers, and environment config, where the cold start impact is most direct. If you want to speed that process up, the [Zod to Valibot migration guide](https://valibot.dev/guides/migrate-from-zod/) covers the key differences and includes a codemod to handle much of the conversion automatically.
 
 ## Where Bundle Size Actually Matters
 

--- a/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
+++ b/website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx
@@ -19,7 +19,7 @@ A big part of the answer lives in your dependencies.
 
 To put a concrete number on this, we built a minimal Cloudflare Worker to understand the cold start cost of our own library compared to Zod, using a single User schema covering name, email, age, and role.
 
-We built it twice using Wrangler 4.81.1 and TypeScript, keeping everything identical except for the validation library being imported. One build used Zod and the other used Valibot. Both builds were done in production mode using Wrangler's default bundling, so minification and tree-shaking are enabled.
+We built it twice using Wrangler 4.81.1 and TypeScript, keeping everything identical except for the validation library being imported. One build used Zod and the other used Valibot. Both builds were done in production mode using Wrangler's default bundling.
 
 Here's what came out of the bundler:
 

--- a/website/src/routes/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/guides/(get-started)/comparison/index.mdx
@@ -29,8 +29,6 @@ This difference affects how much code ends up in your bundle and how you work wi
 
 > The sections below explain these differences in more detail.
 
-Even though Valibot's API resembles other solutions at first glance, the implementation and structure of the source code is very different. In the following, we would like to highlight the differences that can be beneficial for both you and your users.
-
 ## Modular design
 
 Instead of relying on a few large functions with many methods, Valibot's API design and source code is based on many small and independent functions, each with just a single task. This modular design has several advantages.

--- a/website/src/routes/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/guides/(get-started)/comparison/index.mdx
@@ -27,7 +27,6 @@ This difference affects how much code ends up in your bundle and how you work wi
 | Ecosystem | Growing | Extensive |
 | TypeScript inference | ✓ | ✓ |
 
-> The sections below explain these differences in more detail.
 
 ## Modular design
 

--- a/website/src/routes/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/guides/(get-started)/comparison/index.mdx
@@ -13,7 +13,9 @@ contributors:
 
 Valibot and Zod solve the same problem: runtime schema validation with TypeScript type inference. 
 
-Valibot uses small, independent functions. Each validator is a separate import and only included if you use it. This means unused code can be removed during bundling. Zod defines schemas as objects with methods. Validators are attached to the schema and included together, even if only part of the functionality is used.
+Valibot uses small, independent functions. Each validator is a separate import and only included if you use it. This means unused code can be removed during bundling. 
+
+Zod defines schemas as objects with methods. Validators are attached to the schema and included together, even if only part of the functionality is used.
 
 This difference affects how much code ends up in your bundle and how you work with the API.
 

--- a/website/src/routes/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/guides/(get-started)/comparison/index.mdx
@@ -11,6 +11,24 @@ contributors:
 
 # Comparison
 
+Valibot and Zod solve the same problem: runtime schema validation with TypeScript type inference. 
+
+Valibot uses small, independent functions. Each validator is a separate import and only included if you use it. This means unused code can be removed during bundling. Zod defines schemas as objects with methods. Validators are attached to the schema and included together, even if only part of the functionality is used.
+
+This difference affects how much code ends up in your bundle and how you work with the API.
+
+## Quick comparison
+
+| | Valibot | Zod |
+|---|---|---|
+| Bundle size | Small, tree-shakeable | Larger, partially tree-shakeable |
+| API style | Functions | Method chaining |
+| Runtime performance | Faster in most benchmarks | Baseline |
+| Ecosystem | Growing | Extensive |
+| TypeScript inference | ✓ | ✓ |
+
+> The sections below explain these differences in more detail.
+
 Even though Valibot's API resembles other solutions at first glance, the implementation and structure of the source code is very different. In the following, we would like to highlight the differences that can be beneficial for both you and your users.
 
 ## Modular design

--- a/website/src/routes/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/guides/(get-started)/comparison/index.mdx
@@ -11,24 +11,7 @@ contributors:
 
 # Comparison
 
-Valibot and Zod solve the same problem: runtime schema validation with TypeScript type inference. 
-
-Valibot uses small, independent functions. Each validator is a separate import and only included if you use it. This means unused code can be removed during bundling. 
-
-Zod defines schemas as objects with methods. Validators are attached to the schema and included together, even if only part of the functionality is used.
-
-This difference affects how much code ends up in your bundle and how you work with the API.
-
-## Quick comparison
-
-| | Valibot | Zod |
-|---|---|---|
-| Bundle size | Small, tree-shakeable | Larger, partially tree-shakeable |
-| API style | Functions | Method chaining |
-| Runtime performance | Faster in most benchmarks | Baseline |
-| Ecosystem | Growing | Extensive |
-| TypeScript inference | ✓ | ✓ |
-
+Even though Valibot's API resembles other solutions at first glance, the implementation and structure of the source code is very different. In the following, we would like to highlight the differences that can be beneficial for both you and your users.
 
 ## Modular design
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publishes a blog post on how dependency size affects cold starts in edge runtimes, using a `valibot` vs `zod` bundle size experiment with clarified comparison, build details, and migration guidance.

- **New Features**
  - New post at `website/src/routes/blog/(posts)/dependency-size-and-cold-starts/index.mdx` comparing bundle sizes (`zod@4.3.6` 26.75 KiB vs `valibot@1.3.1` 2.72 KiB; 9.8x smaller), why size impacts initialization, and confirmation that namespace imports remain tree-shakeable. Published date set to 2026-05-26.
  - Clarifies scope (default `zod`, not `zod/mini`; baseline installs; primary APIs), exact Cloudflare Workers build setup (Wrangler 4.81.1, TypeScript, production mode), ecosystem support (Standard Schema, tRPC, `@hookform/resolvers`, `@hono/valibot-validator`, `@conform-to/valibot`), and adds migration advice with a link to the Zod→Valibot guide.

<sup>Written for commit f08099f9d8d68cffffd3ac2bc1569525aae4cd9b. Summary will update on new commits. <a href="https://cubic.dev/pr/open-circle/valibot/pull/1458?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

