### PR TITLE
fix(to-json-schema): inline getDefault to remove runtime valibot peer dep import

### DIFF
--- a/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
+++ b/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
@@ -490,7 +490,6 @@ export function convertSchema(
 
       // Add default value to JSON Schema, if available
       if (valibotSchema.default !== undefined) {
-        // @ts-expect-error
         jsonSchema.default =
           typeof valibotSchema.default === 'function'
             ? valibotSchema.default()
@@ -513,7 +512,6 @@ export function convertSchema(
 
       // Add default value to JSON Schema, if available
       if (valibotSchema.default !== undefined) {
-        // @ts-expect-error
         jsonSchema.default =
           typeof valibotSchema.default === 'function'
             ? valibotSchema.default()

--- a/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
+++ b/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
@@ -1,4 +1,4 @@
-import * as v from 'valibot';
+import type * as v from 'valibot';
 import type {
   ConversionConfig,
   ConversionContext,
@@ -491,7 +491,10 @@ export function convertSchema(
       // Add default value to JSON Schema, if available
       if (valibotSchema.default !== undefined) {
         // @ts-expect-error
-        jsonSchema.default = v.getDefault(valibotSchema);
+        jsonSchema.default =
+          typeof valibotSchema.default === 'function'
+            ? valibotSchema.default()
+            : valibotSchema.default;
       }
 
       break;
@@ -511,7 +514,10 @@ export function convertSchema(
       // Add default value to JSON Schema, if available
       if (valibotSchema.default !== undefined) {
         // @ts-expect-error
-        jsonSchema.default = v.getDefault(valibotSchema);
+        jsonSchema.default =
+          typeof valibotSchema.default === 'function'
+            ? valibotSchema.default()
+            : valibotSchema.default;
       }
 
       break;


### PR DESCRIPTION
Fixes #1448.

## Problem

`convertSchema.ts` imports `valibot` as a runtime dependency (`import * as v from 'valibot'`) and calls `v.getDefault(valibotSchema)` in two places. Since `valibot` is a peer dependency, this runtime import ends up in the compiled output and throws when `valibot` is not installed.

```
Error: Cannot find module 'valibot'
```

## Fix

Replace the two `v.getDefault(...)` calls with the inlined equivalent (3 lines each) and change the import to `import type`, so `valibot` is used only for types at compile time and has zero presence in the emitted bundle.

`getDefault` is defined as:
```ts
const getDefault = (schema) =>
  typeof schema.default === 'function' ? schema.default() : schema.default;
```

Inlining this directly removes the only two runtime references to `v`, making the peer dependency purely a type-level concern.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the runtime `valibot` import from `to-json-schema` by inlining `getDefault`, preventing crashes when the peer dep isn’t installed and keeping `valibot` type-only in the build.

- **Bug Fixes**
  - Inlined `getDefault` in two spots, switched to `import type * as v from 'valibot'`, and removed unnecessary `@ts-expect-error` comments on defaults.
  - Fixes "Cannot find module 'valibot'" at runtime; no runtime references to `valibot` remain.

<sup>Written for commit 56c41b9d9e50628032eefc914a4d7291aec5a5f6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

