### PR TITLE
bugfix: Mastercard regex to ensure proper validation and add test for invalid length

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `creditCard` validation action to reject Mastercard numbers with invalid lengths (pull request #1462)
+
 ## v1.3.1 (March 18, 2026)
 
 - Change `MAC48_REGEX`, `MAC64_REGEX` and `MAC_REGEX` to drop the `i` flag for better JSON Schema compatibility (pull request #1430)

--- a/library/src/actions/creditCard/creditCard.test.ts
+++ b/library/src/actions/creditCard/creditCard.test.ts
@@ -188,5 +188,14 @@ describe('creditCard', () => {
         '371449635398434',
       ]);
     });
+
+    test('for Mastercard with invalid length', () => {
+      expectActionIssue(action, baseIssue, [
+        '5100000000003',
+        '510000000000003',
+        '51000000000000003',
+        '5100000000000000003',
+      ]);
+    });
   });
 });

--- a/library/src/actions/creditCard/creditCard.ts
+++ b/library/src/actions/creditCard/creditCard.ts
@@ -85,8 +85,7 @@ const PROVIDER_REGEX_LIST = [
   // JCB
   /^(?:2131|1800|35\d{3})\d{11}$/u,
   // Mastercard
-  // eslint-disable-next-line redos-detector/no-unsafe-regex
-  /^5[1-5]\d{2}|(?:222\d|22[3-9]\d|2[3-6]\d{2}|27[01]\d|2720)\d{12}$/u,
+  /^(?:5[1-5]\d{2}|222\d|22[3-9]\d|2[3-6]\d{2}|27[01]\d|2720)\d{12}$/u,
   // UnionPay
   /^(?:6[27]\d{14,17}|81\d{14,17})$/u,
   // Visa


### PR DESCRIPTION
# Fix Mastercard provider regex precedence bug

## Problem

The Mastercard provider regex in the `creditCard` action is missing parentheses around the alternation, so `|` binds looser than intended:

```js
// library/src/actions/creditCard/creditCard.ts
/^5[1-5]\d{2}|(?:222\d|22[3-9]\d|2[3-6]\d{2}|27[01]\d|2720)\d{12}$/u
```

Due to operator precedence, this is interpreted as two top-level alternatives:

1. `^5[1-5]\d{2}` — matches just the first 4 digits, with **no end anchor and no length constraint** on the rest of the string
2. `(?:222\d|22[3-9]\d|2[3-6]\d{2}|27[01]\d|2720)\d{12}$` — the intended 16-digit pattern for the 22XX–27XX range

The first alternative makes `regex.test(input)` return `true` for any string whose first 4 characters match `5[1-5]\d{2}`, regardless of total length. Combined with the outer `CREDIT_CARD_REGEX` (which accepts 13–19 digits) and Luhn validation, non-16-digit numbers can be incorrectly classified as Mastercard.

For example, the 13-digit number `5100000000003` is Luhn-valid, starts with `5100`, and matches no other provider — but the buggy regex still accepts it as Mastercard.

## Fix

Wrap the alternation in a non-capturing group so every alternative shares the trailing `\d{12}$` suffix, requiring exactly 16 digits:

```js
/^(?:5[1-5]\d{2}|222\d|22[3-9]\d|2[3-6]\d{2}|27[01]\d|2720)\d{12}$/u
```

The `// eslint-disable-next-line redos-detector/no-unsafe-regex` directive above the line is no longer flagged after the fix and has been removed.

## Tests

Added a new test case `for Mastercard with invalid length` covering Luhn-valid numbers starting with `5[1-5]XX` at 13 / 15 / 17 / 19 digits — all of which were previously accepted but should be rejected:

- `5100000000003` (13 digits)
- `510000000000003` (15 digits)
- `51000000000000003` (17 digits)
- `5100000000000000003` (19 digits)

All existing test fixtures (`5555555555554444`, `2223003122003222`, `5200828282828210`, `5105105105105100`) continue to pass — the fix does not change behavior for valid 16-digit Mastercard numbers.



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Mastercard validation to require valid prefixes with exactly 16 digits, preventing partial matches. Added tests for invalid lengths and updated the changelog.

<sup>Written for commit 1dbdb86be1bb4108c2a6d69bd40c60daaa4219ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



