### PR TITLE
fix(multipleOf): avoid floating-point false negatives for decimal divisors

### DIFF
--- a/library/src/actions/multipleOf/multipleOf.test.ts
+++ b/library/src/actions/multipleOf/multipleOf.test.ts
@@ -68,6 +68,12 @@ describe('multipleOf', () => {
     test('for valid bigints', () => {
       expectNoActionIssue(multipleOf(5n), [-15n, -10n, -5n, 0n, 5n, 10n, 15n]);
     });
+
+    test('for valid decimal numbers without floating-point error', () => {
+      // Native `%` reports `0.3 % 0.1` as `0.0999…`, wrongly rejecting these.
+      expectNoActionIssue(multipleOf(0.1), [0.1, 0.2, 0.3, 0.6, 0.9, 1.1, -0.3]);
+      expectNoActionIssue(multipleOf(0.2), [0.2, 0.4, 0.6, -0.6]);
+    });
   });
 
   describe('should return dataset with issues', () => {

--- a/library/src/actions/multipleOf/multipleOf.ts
+++ b/library/src/actions/multipleOf/multipleOf.ts
@@ -11,6 +11,34 @@ import { _addIssue } from '../../utils/index.ts';
 type Input = number | bigint;
 
 /**
+ * Returns the remainder of `value / requirement` without the floating-point
+ * error of the native `%` operator (e.g. `0.3 % 0.1` is `0.0999…`, not `0`, so
+ * `multipleOf(0.1)` would wrongly reject `0.3`). Both operands are scaled to
+ * integers by their decimal-place count before the modulo. Falls back to the
+ * native operator for numbers in exponential notation, where the decimal count
+ * cannot be derived from the string representation.
+ *
+ * @param value The dividend.
+ * @param requirement The divisor.
+ *
+ * @returns The floating-point-safe remainder.
+ */
+// @__NO_SIDE_EFFECTS__
+function _floatSafeRemainder(value: number, requirement: number): number {
+  const valueString = `${value}`;
+  const requirementString = `${requirement}`;
+  if (valueString.includes('e') || requirementString.includes('e')) {
+    return value % requirement;
+  }
+  const decimals = Math.max(
+    valueString.split('.')[1]?.length ?? 0,
+    requirementString.split('.')[1]?.length ?? 0
+  );
+  const scale = 10 ** decimals;
+  return (Math.round(value * scale) % Math.round(requirement * scale)) / scale;
+}
+
+/**
  * Multiple of issue interface.
  */
 export interface MultipleOfIssue<
@@ -155,8 +183,16 @@ export function multipleOf(
     requirement,
     message,
     '~run'(dataset, config) {
-      // @ts-expect-error
-      if (dataset.typed && dataset.value % this.requirement != 0) {
+      if (
+        dataset.typed &&
+        (typeof dataset.value === 'bigint'
+          ? // @ts-expect-error
+            dataset.value % this.requirement !== 0n
+          : _floatSafeRemainder(
+              dataset.value,
+              this.requirement as number
+            ) !== 0)
+      ) {
         _addIssue(this, 'multiple', dataset, config);
       }
       return dataset;


### PR DESCRIPTION
## What

`multipleOf` rejects valid decimal multiples because the native `%` operator
carries floating-point error: `0.3 % 0.1` is `0.0999…`, not `0`.

```ts
v.parse(v.pipe(v.number(), v.multipleOf(0.1)), 0.3); // ❌ throws — but 0.3 is a multiple of 0.1
```

Reproduced for `0.3/0.1`, `0.6/0.2`, `0.9/0.1`, `1.1/0.1`, etc.

## Why it's easy to miss

Integer divisors — the common case, and the only ones covered by the existing
tests — work correctly, so the bug never surfaces in normal use or CI. It only
appears with decimal divisors.

## Fix

Scale both operands to integers by their decimal-place count before taking the
modulo (`_floatSafeRemainder`). The `bigint` path and numbers in exponential
notation fall back to the native operator (both already exact). No public API or
signature change; the only behavioural difference is that genuine decimal
multiples now pass. This mirrors the float-safe remainder Zod adopted for the
same issue.

## Tests

Added regression tests for decimal multiples (`multipleOf(0.1)` and
`multipleOf(0.2)`). Full `multipleOf` suite: **11/11 pass**, `tsc --noEmit` and
ESLint clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `multipleOf` rejecting valid decimal multiples by using a float-safe remainder. Decimal divisors like `0.1` now work as expected (e.g., `0.3`, `0.6`, `1.1` pass).

- **Bug Fixes**
  - Added `_floatSafeRemainder` that scales operands to integers before modulo; falls back for exponential notation; bigint path unchanged.
  - Updated `multipleOf` to use the float-safe path for numbers; integer divisors behave the same.
  - Added regression tests for decimal divisors (`0.1`, `0.2`); no public API changes.

<sup>Written for commit 2a981dd8040dfa37f466215699779a4ec1be7f41. Summary will update on new commits. <a href="https://cubic.dev/pr/open-circle/valibot/pull/1470?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

