### PR TITLE
Fix intersect schema to infer correct types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ pnpm build                      # Build for publishing (all packages)
 ## Other Rules
 
 - **Source code is the single source of truth.** All documentation must match `/library/src/`.
-- **Lint and format after modifying code.** Run `pnpm lint` and `pnpm format` so CI passes.
+- **Lint and format after modifying code.** Run `eslint --fix` and `prettier --write` on the files you changed so CI passes.
 - **Use the GitHub CLI for GitHub-related tasks.** Prefer `gh` for pull requests, issues, checks, and other GitHub operations.
 
 ## Library Architecture

--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `intersect` schema to infer correct input and output types for non-tuple array options instead of `never` (pull request #1478)
+
 ## v1.4.0 (May 05, 2026)
 
 - Add `isoDateTimeSecond` validation action to validate ISO date times with seconds (pull request #1418)

--- a/library/src/schemas/intersect/intersect.test-d.ts
+++ b/library/src/schemas/intersect/intersect.test-d.ts
@@ -69,6 +69,25 @@ describe('intersect', () => {
     });
   });
 
+  describe('should infer never for empty options', () => {
+    // `intersect([])` is a guaranteed runtime failure (it reports a `never`
+    // expectation), so its input and output types must stay `never`. The real
+    // call infers `never[]` for the options, not the empty tuple `[]`, so both
+    // shapes are asserted here.
+    type EmptyTupleSchema = IntersectSchema<[], undefined>;
+    type EmptyArraySchema = IntersectSchema<never[], undefined>;
+
+    test('of input', () => {
+      expectTypeOf<InferInput<EmptyTupleSchema>>().toEqualTypeOf<never>();
+      expectTypeOf<InferInput<EmptyArraySchema>>().toEqualTypeOf<never>();
+    });
+
+    test('of output', () => {
+      expectTypeOf<InferOutput<EmptyTupleSchema>>().toEqualTypeOf<never>();
+      expectTypeOf<InferOutput<EmptyArraySchema>>().toEqualTypeOf<never>();
+    });
+  });
+
   describe('should infer correct types for non-tuple array options', () => {
     // A general array of options (not a fixed tuple) — e.g. when building an
     // intersect dynamically or annotating `IntersectSchema<Schema[], ...>`.

--- a/library/src/schemas/intersect/intersect.test-d.ts
+++ b/library/src/schemas/intersect/intersect.test-d.ts
@@ -1,10 +1,10 @@
 import { describe, expectTypeOf, test } from 'vitest';
 import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
 import { array, type ArrayIssue } from '../array/index.ts';
-import { number, type NumberIssue } from '../number/index.ts';
-import { object, type ObjectIssue } from '../object/index.ts';
+import { number, type NumberIssue, type NumberSchema } from '../number/index.ts';
+import { object, type ObjectIssue, type ObjectSchema } from '../object/index.ts';
 import { optional } from '../optional/optional.ts';
-import { string, type StringIssue } from '../string/index.ts';
+import { string, type StringIssue, type StringSchema } from '../string/index.ts';
 import { intersect, type IntersectSchema } from './intersect.ts';
 import type { IntersectIssue } from './types.ts';
 
@@ -53,6 +53,28 @@ describe('intersect', () => {
     test('of issue', () => {
       expectTypeOf<InferIssue<Schema>>().toEqualTypeOf<
         IntersectIssue | ArrayIssue | ObjectIssue | StringIssue | NumberIssue
+      >();
+    });
+  });
+
+  describe('should infer correct types for non-tuple array options', () => {
+    // A general array of options (not a fixed tuple) — e.g. when building an
+    // intersect dynamically or annotating `IntersectSchema<Schema[], ...>`.
+    type ArrayOptions = (
+      | ObjectSchema<{ key1: StringSchema<undefined> }, undefined>
+      | ObjectSchema<{ key2: NumberSchema<undefined> }, undefined>
+    )[];
+    type Schema = IntersectSchema<ArrayOptions, undefined>;
+
+    test('of input', () => {
+      expectTypeOf<InferInput<Schema>>().toEqualTypeOf<
+        { key1: string } & { key2: number }
+      >();
+    });
+
+    test('of output', () => {
+      expectTypeOf<InferOutput<Schema>>().toEqualTypeOf<
+        { key1: string } & { key2: number }
       >();
     });
   });

--- a/library/src/schemas/intersect/intersect.test-d.ts
+++ b/library/src/schemas/intersect/intersect.test-d.ts
@@ -1,10 +1,22 @@
 import { describe, expectTypeOf, test } from 'vitest';
 import type { InferInput, InferIssue, InferOutput } from '../../types/index.ts';
 import { array, type ArrayIssue } from '../array/index.ts';
-import { number, type NumberIssue, type NumberSchema } from '../number/index.ts';
-import { object, type ObjectIssue, type ObjectSchema } from '../object/index.ts';
+import {
+  number,
+  type NumberIssue,
+  type NumberSchema,
+} from '../number/index.ts';
+import {
+  object,
+  type ObjectIssue,
+  type ObjectSchema,
+} from '../object/index.ts';
 import { optional } from '../optional/optional.ts';
-import { string, type StringIssue, type StringSchema } from '../string/index.ts';
+import {
+  string,
+  type StringIssue,
+  type StringSchema,
+} from '../string/index.ts';
 import { intersect, type IntersectSchema } from './intersect.ts';
 import type { IntersectIssue } from './types.ts';
 

--- a/library/src/schemas/intersect/types.ts
+++ b/library/src/schemas/intersect/types.ts
@@ -2,7 +2,10 @@ import type {
   BaseIssue,
   BaseSchema,
   BaseSchemaAsync,
+  InferInput,
+  InferOutput,
   MaybeReadonly,
+  UnionToIntersect,
 } from '../../types/index.ts';
 
 /**
@@ -62,7 +65,7 @@ export type InferIntersectInput<
     ]
     ? TInput & InferIntersectInput<TRest>
     : TInput
-  : never;
+  : UnionToIntersect<InferInput<TOptions[number]>>;
 
 /**
  * Infer intersect output type.
@@ -79,4 +82,4 @@ export type InferIntersectOutput<
     ]
     ? TOutput & InferIntersectOutput<TRest>
     : TOutput
-  : never;
+  : UnionToIntersect<InferOutput<TOptions[number]>>;

--- a/library/src/schemas/intersect/types.ts
+++ b/library/src/schemas/intersect/types.ts
@@ -4,6 +4,7 @@ import type {
   BaseSchemaAsync,
   InferInput,
   InferOutput,
+  IsNever,
   MaybeReadonly,
   UnionToIntersect,
 } from '../../types/index.ts';
@@ -65,7 +66,9 @@ export type InferIntersectInput<
     ]
     ? TInput & InferIntersectInput<TRest>
     : TInput
-  : UnionToIntersect<InferInput<TOptions[number]>>;
+  : IsNever<TOptions[number]> extends true
+    ? never
+    : UnionToIntersect<InferInput<TOptions[number]>>;
 
 /**
  * Infer intersect output type.
@@ -82,4 +85,6 @@ export type InferIntersectOutput<
     ]
     ? TOutput & InferIntersectOutput<TRest>
     : TOutput
-  : UnionToIntersect<InferOutput<TOptions[number]>>;
+  : IsNever<TOptions[number]> extends true
+    ? never
+    : UnionToIntersect<InferOutput<TOptions[number]>>;


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the `intersect` schema so non-tuple array options infer the correct input/output types instead of `never`, and ensures empty options still infer `never`. This restores proper intersection behavior and improves type safety.

- Bug Fixes
  - Use `UnionToIntersect` with `InferInput<TOptions[number]>` and `InferOutput<TOptions[number]>` for array options.
  - Preserve `never` for empty options via `IsNever<TOptions[number]>`; add dts tests for `[]` and `never[]`.
  - Add dts tests for non-tuple `Schema[]` cases, refactor test imports, and update lint/format instructions in `AGENTS.md`.

<sup>Written for commit dba93a96d7aba0a61376bde20acae364a79057f0. Summary will update on new commits. <a href="https://cubic.dev/pr/open-circle/valibot/pull/1478?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

