### PR TITLE
Bump version to 1.4.1 and update changelog for release

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.4.1 (May 24, 2026)
 
 - Fix `intersect` schema to infer correct input and output types for non-tuple array options instead of `never` (pull request #1478)
 

--- a/library/jsr.json
+++ b/library/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@valibot/valibot",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "exports": "./src/index.ts",
   "publish": {
     "include": ["src/**/*.ts", "README.md"],

--- a/library/package.json
+++ b/library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valibot",
   "description": "The modular and type safe schema library for validating structural data",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://valibot.dev",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prepare the 1.4.1 release by bumping versions in `valibot` and `@valibot/valibot` and updating the changelog. This patch includes the `intersect` schema fix to correctly infer types for non-tuple array options instead of `never`.

<sup>Written for commit 0b2b2ec592173b832bb72b29e842a135152d3fad. Summary will update on new commits. <a href="https://cubic.dev/pr/open-circle/valibot/pull/1479?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

