### PR TITLE
Fix stringifyJson to preserve original value when serialization fails

### DIFF
--- a/library/src/actions/stringifyJson/stringifyJson.ts
+++ b/library/src/actions/stringifyJson/stringifyJson.ts
@@ -149,8 +149,10 @@ export function stringifyJson(
           _addIssue(this, 'JSON', dataset, config);
           // @ts-expect-error
           dataset.typed = false;
+        } else {
+          // Only assign value when serialization succeeds
+          dataset.value = output;
         }
-        dataset.value = output;
       } catch (error) {
         if (error instanceof Error) {
           _addIssue(this, 'JSON', dataset, config, {


### PR DESCRIPTION
previously when JSON.stringify returned undefined, the code would still overwrite dataset.value with undefined, corrupting downstream processing. now the original value is preserved when serialization fails

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent data loss in `stringifyJson` by preserving the original value when JSON serialization fails or returns undefined. This avoids downstream corruption caused by overwriting with undefined.

- **Bug Fixes**
  - Only assign `dataset.value` when serialization succeeds; otherwise keep the original value and mark `dataset.typed = false`.

<sup>Written for commit 9896b12bbebeaa891350f166dfd4623af6689eb0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/valibot/pull/1483?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

