### PR TITLE
fix(to-json-schema): encode JSON Pointer special chars in $ref tokens

### DIFF
--- a/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
+++ b/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
@@ -4,7 +4,11 @@ import type {
   ConversionContext,
   JsonSchema,
 } from '../../types/index.ts';
-import { addError, handleError } from '../../utils/index.ts';
+import {
+  addError,
+  encodePointerToken,
+  handleError,
+} from '../../utils/index.ts';
 import { convertAction } from '../convertAction/index.ts';
 
 /**
@@ -148,7 +152,7 @@ export function convertSchema(
     // If schema is in reference map use reference and skip conversion
     const referenceId = context.referenceMap.get(valibotSchema);
     if (referenceId) {
-      jsonSchema.$ref = `#/$defs/${referenceId}`;
+      jsonSchema.$ref = `#/$defs/${encodePointerToken(referenceId)}`;
       if (config?.overrideRef) {
         const refOverride = config.overrideRef({
           ...context,
@@ -631,7 +635,7 @@ export function convertSchema(
       }
 
       // Add reference to JSON Schema object
-      jsonSchema.$ref = `#/$defs/${referenceId}`;
+      jsonSchema.$ref = `#/$defs/${encodePointerToken(referenceId)}`;
 
       // Override reference, if necessary
       if (config?.overrideRef) {

--- a/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.test.ts
+++ b/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.test.ts
@@ -95,6 +95,29 @@ describe('toJsonSchema', () => {
       }
     });
 
+    test('for definition key containing JSON Pointer special characters', () => {
+      const UserSchema = v.object({ name: v.string() });
+      expect(
+        toJsonSchema(v.object({ user: UserSchema }), {
+          definitions: { 'Shared/User~': UserSchema },
+        })
+      ).toStrictEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          user: { $ref: '#/$defs/Shared~1User~0' },
+        },
+        required: ['user'],
+        $defs: {
+          'Shared/User~': {
+            type: 'object',
+            properties: { name: { type: 'string' } },
+            required: ['name'],
+          },
+        },
+      });
+    });
+
     test('for recursive schema', () => {
       const ul = v.object({
         type: v.literal('ul'),

--- a/packages/to-json-schema/src/utils/encodePointerToken.ts
+++ b/packages/to-json-schema/src/utils/encodePointerToken.ts
@@ -1,0 +1,14 @@
+/**
+ * Encodes a string as a JSON Pointer reference token per RFC 6901.
+ *
+ * The two characters that must be escaped are:
+ * - `~` → `~0`
+ * - `/` → `~1`
+ *
+ * @param token The token to encode.
+ *
+ * @returns The encoded token.
+ */
+export function encodePointerToken(token: string): string {
+  return token.replace(/~/g, '~0').replace(/\//g, '~1');
+}

--- a/packages/to-json-schema/src/utils/index.ts
+++ b/packages/to-json-schema/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './addError.ts';
+export * from './encodePointerToken.ts';
 export * from './escapeRegExp.ts';
 export * from './handleError.ts';
 export * from './isJsonConstValue.ts';


### PR DESCRIPTION
## Bug

When `toJsonSchema()` is called with a `definitions` object whose keys contain `/` or `~`, the generated `$ref` URI fragments are invalid per [RFC 6901 (JSON Pointer)](https://datatracker.ietf.org/doc/html/rfc6901).

For example:

```ts
const UserSchema = v.object({ name: v.string() });
toJsonSchema(
  v.object({ user: UserSchema }),
  { definitions: { 'Shared/User~': UserSchema } }
);
```

**Actual** (broken):
```json
{ "user": { "$ref": "#/$defs/Shared/User~" } }
```

**Expected** (correct per RFC 6901):
```json
{ "user": { "$ref": "#/$defs/Shared~1User~0" } }
```

RFC 6901 requires two escapes inside pointer reference tokens:
- `~` → `~0`
- `/` → `~1`

The `$defs` object key itself is an ordinary JSON key and is **not** encoded — only the pointer path inside `$ref` needs encoding.

## Root cause

Both `$ref`-construction sites in `convertSchema.ts` used the raw `referenceId` string (e.g. `` `#/$defs/${referenceId}` ``) without applying the RFC 6901 escapes.

## Fix

- Adds `encodePointerToken(token: string): string` utility in `packages/to-json-schema/src/utils/encodePointerToken.ts`
- Applies it at both `$ref` construction sites in `convertSchema.ts`
- Adds a regression test covering `/` and `~` in definition keys

## Test evidence

```
Test Files  6 passed (6)
     Tests  222 passed (222)
Type Errors  no errors
```

Closes #1481

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes invalid `$ref` fragments in `to-json-schema` when definition keys contain `/` or `~`. JSON Pointer tokens are now encoded per RFC 6901 so generated refs are valid.

- **Bug Fixes**
  - Add `encodePointerToken()` to escape `~` → `~0` and `/` → `~1` in `$ref` tokens.
  - Apply encoding at both `$ref` construction sites in `convertSchema.ts`.
  - Do not encode `$defs` keys; only the `$ref` pointer path is encoded.
  - Add a regression test for keys containing `/` and `~`.

<sup>Written for commit b3c824c01989d2a52db8c0f2a850bb78645619e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/valibot/pull/1493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

