### PR TITLE
docs: clarify string length semantics

### DIFF
--- a/library/src/actions/length/length.test.ts
+++ b/library/src/actions/length/length.test.ts
@@ -72,6 +72,7 @@ describe('length', () => {
         'ABC',
         '123',
         'あああ', // 'あ' is 3 bytes but the total length of the string is 3
+        '😀a',
         '@#$',
       ]);
     });
@@ -109,6 +110,10 @@ describe('length', () => {
           '\n',
           '\n\t',
           'あ', // 'あ' is 3 bytes
+          '😀',
+          '😀😀',
+          '😀😀😀',
+          '👨‍👩‍👧‍👦',
           'ab',
           'abcd',
           '1',

--- a/library/src/actions/maxLength/maxLength.test.ts
+++ b/library/src/actions/maxLength/maxLength.test.ts
@@ -68,7 +68,7 @@ describe('maxLength', () => {
     });
 
     test('for valid strings', () => {
-      expectNoActionIssue(action, ['', 'foo', '12345']);
+      expectNoActionIssue(action, ['', 'foo', '12345', '😀😀']);
     });
 
     test('for valid arrays', () => {
@@ -90,7 +90,7 @@ describe('maxLength', () => {
       expectActionIssue(
         action,
         baseIssue,
-        ['123456', 'foobarbaz123'],
+        ['123456', 'foobarbaz123', '😀😀😀'],
         (value) => `${value.length}`
       );
     });

--- a/library/src/actions/minLength/minLength.test.ts
+++ b/library/src/actions/minLength/minLength.test.ts
@@ -68,7 +68,12 @@ describe('minLength', () => {
     });
 
     test('for valid strings', () => {
-      expectNoActionIssue(action, ['12345', '123456', 'foobarbaz123']);
+      expectNoActionIssue(action, [
+        '12345',
+        '123456',
+        'foobarbaz123',
+        '😀😀😀',
+      ]);
     });
 
     test('for valid arrays', () => {
@@ -90,7 +95,7 @@ describe('minLength', () => {
       expectActionIssue(
         action,
         baseIssue,
-        ['', 'foo', '1234'],
+        ['', 'foo', '1234', '😀😀'],
         (value) => `${value.length}`
       );
     });

--- a/packages/to-json-schema/README.md
+++ b/packages/to-json-schema/README.md
@@ -115,6 +115,8 @@ This package is particularly popular for:
 | `value`         | ⚠️     | Only JSON compatible values are supported                   |
 | `values`        | ⚠️     | Only JSON compatible values are supported                   |
 
+> For `length`, `minLength`, and `maxLength`, string constraints have different length semantics in Valibot and JSON Schema. Valibot checks JavaScript string length (`value.length`, UTF-16 code units), while JSON Schema `minLength` and `maxLength` count characters. This can differ for non-BMP characters such as emoji.
+
 ## Configurations
 
 | Option         | Type                                                                  | Note                                                                                                                      |

--- a/packages/to-json-schema/README.md
+++ b/packages/to-json-schema/README.md
@@ -115,7 +115,7 @@ This package is particularly popular for:
 | `value`         | ⚠️     | Only JSON compatible values are supported                   |
 | `values`        | ⚠️     | Only JSON compatible values are supported                   |
 
-> For `length`, `minLength`, and `maxLength`, string constraints have different length semantics in Valibot and JSON Schema. Valibot checks JavaScript string length (`value.length`, UTF-16 code units), while JSON Schema `minLength` and `maxLength` count characters. This can differ for non-BMP characters such as emoji.
+> For `length`, `minLength`, and `maxLength`, string constraints have different length semantics in Valibot and JSON Schema. Valibot checks JavaScript string length (`value.length`, UTF-16 code units), while JSON Schema `minLength` and `maxLength` count Unicode code points. This can differ for non-BMP code points such as emoji and for multi-code-point grapheme clusters such as combining marks or ZWJ sequences.
 
 ## Configurations
 

--- a/website/src/routes/api/(actions)/graphemes/index.mdx
+++ b/website/src/routes/api/(actions)/graphemes/index.mdx
@@ -4,9 +4,10 @@ description: Creates a graphemes validation action.
 source: /actions/graphemes/graphemes.ts
 contributors:
   - fabian-hiller
+  - yslpn
 ---
 
-import { ApiList, Property } from '~/components';
+import { ApiList, Link, Property } from '~/components';
 import { properties } from './properties';
 
 # graphemes
@@ -34,6 +35,8 @@ const Action = v.graphemes<TInput, TRequirement, TMessage>(
 ### Explanation
 
 With `graphemes` you can validate the graphemes of a string. If the input does not match the `requirement`, you can use `message` to customize the error message.
+
+> If you are looking for an equivalent of JavaScript's `.length`, use <Link href="../length/">`length`</Link> instead.
 
 ## Returns
 
@@ -65,6 +68,10 @@ The following APIs can be combined with `graphemes`.
 ### Methods
 
 <ApiList items={['pipe']} />
+
+### Actions
+
+<ApiList items={['length']} />
 
 ### Utils
 

--- a/website/src/routes/api/(actions)/length/index.mdx
+++ b/website/src/routes/api/(actions)/length/index.mdx
@@ -4,9 +4,10 @@ description: Creates a length validation action.
 source: /actions/length/length.ts
 contributors:
   - fabian-hiller
+  - yslpn
 ---
 
-import { ApiList, Property } from '~/components';
+import { ApiList, Link, Property } from '~/components';
 import { properties } from './properties';
 
 # length
@@ -30,7 +31,9 @@ const Action = v.length<TInput, TRequirement, TMessage>(requirement, message);
 
 ### Explanation
 
-With `length` you can validate the length of a string or array. If the input does not match the `requirement`, you can use `message` to customize the error message.
+With `length` you can validate the length of a string or array. For strings, length is measured like JavaScript's `value.length`, i.e. by UTF-16 code units. For arrays, length is measured by the number of items. If the input does not match the `requirement`, you can use `message` to customize the error message.
+
+> If you need to validate the number of user-perceived characters, use <Link href="../graphemes/">`graphemes`</Link> instead.
 
 ## Returns
 
@@ -42,12 +45,12 @@ The following examples show how `length` can be used.
 
 ### String schema
 
-Schema to validate the length of a string.
+Schema to validate a string with a length of 8 UTF-16 code units.
 
 ```ts
 const StringSchema = v.pipe(
   v.string(),
-  v.length(8, 'The string must be 8 characters long.')
+  v.length(8, 'The string must be 8 UTF-16 code units long.')
 );
 ```
 
@@ -75,6 +78,10 @@ The following APIs can be combined with `length`.
 ### Methods
 
 <ApiList items={['pipe']} />
+
+### Actions
+
+<ApiList items={['graphemes']} />
 
 ### Utils
 

--- a/website/src/routes/api/(actions)/maxGraphemes/index.mdx
+++ b/website/src/routes/api/(actions)/maxGraphemes/index.mdx
@@ -5,6 +5,7 @@ source: /actions/maxGraphemes/maxGraphemes.ts
 contributors:
   - fabian-hiller
   - tats-u
+  - yslpn
 ---
 
 import { ApiList, Link, Property } from '~/components';
@@ -35,6 +36,8 @@ const Action = v.maxGraphemes<TInput, TRequirement, TMessage>(
 ### Explanation
 
 With `maxGraphemes` you can validate the graphemes of a string. If the input does not match the `requirement`, you can use `message` to customize the error message.
+
+> If you are looking for an equivalent of JavaScript's `.length` for maximum length checks, use <Link href="../maxLength/">`maxLength`</Link> instead.
 
 > Hint: The number of characters per grapheme is not limited. You may want to consider combining `maxGraphemes` with <Link href="../maxLength/">`maxLength`</Link> or <Link href="../maxBytes/">`maxBytes`</Link> to set a stricter limit.
 
@@ -68,6 +71,10 @@ The following APIs can be combined with `maxGraphemes`.
 ### Methods
 
 <ApiList items={['pipe']} />
+
+### Actions
+
+<ApiList items={['maxLength']} />
 
 ### Utils
 

--- a/website/src/routes/api/(actions)/maxLength/index.mdx
+++ b/website/src/routes/api/(actions)/maxLength/index.mdx
@@ -5,9 +5,10 @@ source: /actions/maxLength/maxLength.ts
 contributors:
   - fabian-hiller
   - depsimon
+  - yslpn
 ---
 
-import { ApiList, Property } from '~/components';
+import { ApiList, Link, Property } from '~/components';
 import { properties } from './properties';
 
 # maxLength
@@ -34,7 +35,9 @@ const Action = v.maxLength<TInput, TRequirement, TMessage>(
 
 ### Explanation
 
-With `maxLength` you can validate the length of a string or array. If the input does not match the `requirement`, you can use `message` to customize the error message.
+With `maxLength` you can validate the length of a string or array. For strings, length is measured like JavaScript's `value.length`, i.e. by UTF-16 code units. For arrays, length is measured by the number of items. If the input does not match the `requirement`, you can use `message` to customize the error message.
+
+> If you need to validate the maximum number of user-perceived characters, use <Link href="../maxGraphemes/">`maxGraphemes`</Link> instead.
 
 ## Returns
 
@@ -46,12 +49,12 @@ The following examples show how `maxLength` can be used.
 
 ### Maximum string length
 
-Schema to validate a string with a maximum length of 32 characters.
+Schema to validate a string with a maximum length of 32 UTF-16 code units.
 
 ```ts
 const MaxStringSchema = v.pipe(
   v.string(),
-  v.maxLength(32, 'The string must not exceed 32 characters.')
+  v.maxLength(32, 'The string must not exceed 32 UTF-16 code units.')
 );
 ```
 
@@ -79,6 +82,10 @@ The following APIs can be combined with `maxLength`.
 ### Methods
 
 <ApiList items={['pipe']} />
+
+### Actions
+
+<ApiList items={['maxGraphemes']} />
 
 ### Utils
 

--- a/website/src/routes/api/(actions)/minGraphemes/index.mdx
+++ b/website/src/routes/api/(actions)/minGraphemes/index.mdx
@@ -4,9 +4,10 @@ description: Creates a min graphemes validation action.
 source: /actions/minGraphemes/minGraphemes.ts
 contributors:
   - fabian-hiller
+  - yslpn
 ---
 
-import { ApiList, Property } from '~/components';
+import { ApiList, Link, Property } from '~/components';
 import { properties } from './properties';
 
 # minGraphemes
@@ -34,6 +35,8 @@ const Action = v.minGraphemes<TInput, TRequirement, TMessage>(
 ### Explanation
 
 With `minGraphemes` you can validate the graphemes of a string. If the input does not match the `requirement`, you can use `message` to customize the error message.
+
+> If you are looking for an equivalent of JavaScript's `.length` for minimum length checks, use <Link href="../minLength/">`minLength`</Link> instead.
 
 ## Returns
 
@@ -65,6 +68,10 @@ The following APIs can be combined with `minGraphemes`.
 ### Methods
 
 <ApiList items={['pipe']} />
+
+### Actions
+
+<ApiList items={['minLength']} />
 
 ### Utils
 

--- a/website/src/routes/api/(actions)/minLength/index.mdx
+++ b/website/src/routes/api/(actions)/minLength/index.mdx
@@ -5,9 +5,10 @@ source: /actions/minLength/minLength.ts
 contributors:
   - fabian-hiller
   - depsimon
+  - yslpn
 ---
 
-import { ApiList, Property } from '~/components';
+import { ApiList, Link, Property } from '~/components';
 import { properties } from './properties';
 
 # minLength
@@ -34,7 +35,9 @@ const Action = v.minLength<TInput, TRequirement, TMessage>(
 
 ### Explanation
 
-With `minLength` you can validate the length of a string or array. If the input does not match the `requirement`, you can use `message` to customize the error message.
+With `minLength` you can validate the length of a string or array. For strings, length is measured like JavaScript's `value.length`, i.e. by UTF-16 code units. For arrays, length is measured by the number of items. If the input does not match the `requirement`, you can use `message` to customize the error message.
+
+> If you need to validate the minimum number of user-perceived characters, use <Link href="../minGraphemes/">`minGraphemes`</Link> instead.
 
 ## Returns
 
@@ -46,12 +49,12 @@ The following examples show how `minLength` can be used.
 
 ### Minimum string length
 
-Schema to validate a string with a minimum length of 3 characters.
+Schema to validate a string with a minimum length of 3 UTF-16 code units.
 
 ```ts
 const MinStringSchema = v.pipe(
   v.string(),
-  v.minLength(3, 'The string must be 3 or more characters long.')
+  v.minLength(3, 'The string must be 3 or more UTF-16 code units long.')
 );
 ```
 
@@ -79,6 +82,10 @@ The following APIs can be combined with `minLength`.
 ### Methods
 
 <ApiList items={['pipe']} />
+
+### Actions
+
+<ApiList items={['minGraphemes']} />
 
 ### Utils
 


### PR DESCRIPTION
# Document string length semantics

## Summary

Keep the current runtime behavior for `length`, `minLength`, and `maxLength`: strings are measured with JavaScript `value.length` (UTF-16 code units), and arrays are measured by item count.

This PR documents that behavior explicitly, keeps links between length-based and grapheme-based actions, adds emoji regression tests, and documents the `toJsonSchema` limitation for these actions.

## Motivation

The existing documentation did not make it clear what `length` checks for strings, so this behavior was ambiguous for users.

Since Valibot is a JavaScript-first library, keeping JavaScript `.length` semantics is predictable for users who already know how string length works in JS.

This also matters for `toJsonSchema` compatibility. JSON Schema string length keywords count characters, while Valibot's `length`, `minLength`, and `maxLength` currently count UTF-16 code units. Values with non-BMP characters, such as emoji, can therefore be validated differently by Valibot and by JSON Schema validators.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarifies string length semantics across docs and tests: `length`, `minLength`, and `maxLength` use JavaScript `value.length` (UTF‑16 code units) for strings; arrays use item count. Adds links between length/grapheme actions, updates examples, documents in `to-json-schema` that JSON Schema counts code points, and expands emoji/ZWJ tests.

<sup>Written for commit e6609a23edda37c6a58e2621075fdf818577a8b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/valibot/pull/1505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

