### PR TITLE
Handle zod/v4-mini imports in the Zod codemod

### DIFF
--- a/codemod/zod-to-valibot/__testfixtures__/multiple-imports-from-zod/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/multiple-imports-from-zod/output.ts
@@ -1,4 +1,4 @@
-/* @valibot-migrate: unable to transform imports from Zod to Valibot: Expected exactly one import specifier from "zod" or "zod/v4". */
+/* @valibot-migrate: unable to transform imports from Zod to Valibot: Expected exactly one import specifier from "zod", "zod/v4", or "zod/v4-mini". */
 import { z, ZodAnyType } from "zod";
 
 const Schema1 = z.string();

--- a/codemod/zod-to-valibot/__testfixtures__/zod-v4-mini-import/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/zod-v4-mini-import/input.ts
@@ -1,0 +1,3 @@
+import { z } from "zod/v4-mini";
+
+export const StationNumberSchema = z.string();

--- a/codemod/zod-to-valibot/__testfixtures__/zod-v4-mini-import/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/zod-v4-mini-import/output.ts
@@ -1,0 +1,3 @@
+import * as v from "valibot";
+
+export const StationNumberSchema = v.string();

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -74,4 +74,5 @@ defineTests(transform, [
   'validation-error-msg',
   'void-schema',
   'zod-enum',
+  'zod-v4-mini-import',
 ]);

--- a/codemod/zod-to-valibot/src/transform/imports/imports.ts
+++ b/codemod/zod-to-valibot/src/transform/imports/imports.ts
@@ -1,7 +1,12 @@
 import j, { type Collection } from 'jscodeshift';
 
-const ZOD_IMPORT_SOURCES = new Set(['zod', 'zod/v4', 'zod/v4-mini']);
-const ZOD_IMPORT_SOURCES_LABEL = '"zod", "zod/v4", or "zod/v4-mini"';
+const ZOD_IMPORT_SOURCES_LIST = ['zod', 'zod/v4', 'zod/v4-mini'] as const;
+const ZOD_IMPORT_SOURCES = new Set<string>(ZOD_IMPORT_SOURCES_LIST);
+const LAST_ZOD_IMPORT_SOURCE =
+  ZOD_IMPORT_SOURCES_LIST[ZOD_IMPORT_SOURCES_LIST.length - 1];
+const ZOD_IMPORT_SOURCES_LABEL = `${ZOD_IMPORT_SOURCES_LIST.slice(0, -1)
+  .map((source) => `"${source}"`)
+  .join(', ')}, or "${LAST_ZOD_IMPORT_SOURCE}"`;
 
 type TransformImportsReturn =
   | {

--- a/codemod/zod-to-valibot/src/transform/imports/imports.ts
+++ b/codemod/zod-to-valibot/src/transform/imports/imports.ts
@@ -1,5 +1,8 @@
 import j, { type Collection } from 'jscodeshift';
 
+const ZOD_IMPORT_SOURCES = new Set(['zod', 'zod/v4', 'zod/v4-mini']);
+const ZOD_IMPORT_SOURCES_LABEL = '"zod", "zod/v4", or "zod/v4-mini"';
+
 type TransformImportsReturn =
   | {
       conclusion: 'skip' | 'unsuccessful';
@@ -14,14 +17,16 @@ export function transformImports(
   // Find all Zod import statements
   const zodImports = root.find(
     j.ImportDeclaration,
-    (name) => name.source.value === 'zod' || name.source.value === 'zod/v4'
+    (name) =>
+      typeof name.source.value === 'string' &&
+      ZOD_IMPORT_SOURCES.has(name.source.value)
   );
   // Check the number of statements is exactly one
   const importNodes = zodImports.nodes();
   if (importNodes.length !== 1) {
     return {
       conclusion: importNodes.length === 0 ? 'skip' : 'unsuccessful',
-      cause: 'Expected exactly one import statement from "zod" or "zod/v4".',
+      cause: `Expected exactly one import statement from ${ZOD_IMPORT_SOURCES_LABEL}.`,
     };
   }
   // Check the number of specifiers is exactly one
@@ -29,7 +34,7 @@ export function transformImports(
   if (importSpecifiers?.length !== 1) {
     return {
       conclusion: 'unsuccessful',
-      cause: 'Expected exactly one import specifier from "zod" or "zod/v4".',
+      cause: `Expected exactly one import specifier from ${ZOD_IMPORT_SOURCES_LABEL}.`,
     };
   }
   // Obtain the identifier


### PR DESCRIPTION
The Zod-to-Valibot codemod was not treating `zod/v4-mini` as a Zod import source.
This adds `zod/v4-mini` to the recognized sources so those imports are transformed through the same codemod path. I checked it with the codemod tests passing 72/72, the codemod build, Prettier check, and `git diff --check`.
Fixes #1500

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Teach the Zod-to-Valibot codemod to recognize imports from `zod/v4-mini` and keep import-source messages consistent. Fixes #1500.

- **Bug Fixes**
  - Recognize `zod/v4-mini` as a valid Zod import source.
  - Update error messages to list `"zod", "zod/v4", or "zod/v4-mini"`.
  - Add a `zod/v4-mini` test fixture and include it in the test suite.

- **Refactors**
  - Centralize Zod import sources and label generation (single list/Set) to dedupe logic and keep messages in sync.

<sup>Written for commit a7fed2ffeacaebbeedf28b9c9716a762a9420e04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/valibot/pull/1507?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

