### PR TITLE
fix(zod-to-valibot): support .and() method

### DIFF
--- a/codemod/zod-to-valibot/__testfixtures__/and/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/and/input.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+
+const A = z.string().and(z.number());
+const B = z.object({ a: z.string() }).and(z.object({ b: z.number() }));

--- a/codemod/zod-to-valibot/__testfixtures__/and/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/and/output.ts
@@ -1,0 +1,4 @@
+import * as v from "valibot";
+
+const A = v.intersect([v.string(), v.number()]);
+const B = v.intersect([v.object({ a: v.string() }), v.object({ b: v.number() })]);

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -3,6 +3,7 @@ import { defineTests } from './utils';
 
 // maintain the sorted order
 defineTests(transform, [
+  'and',
   'any-schema',
   'array-element',
   'array-nonempty',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
@@ -134,6 +134,7 @@ export const ZOD_PROPERTIES = [
 ] as const;
 
 export const ZOD_METHODS = [
+  'and',
   'array',
   'catchall',
   'default',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/and/and.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/and/and.ts
@@ -1,0 +1,16 @@
+import j from 'jscodeshift';
+
+// `z.string().and(z.number())` -> `v.intersect([v.string(), v.number()])`
+export function transformAnd(
+  valibotIdentifier: string,
+  schemaExp: j.CallExpression | j.MemberExpression | j.Identifier,
+  inputArgs: j.CallExpression['arguments']
+) {
+  return j.callExpression(
+    j.memberExpression(
+      j.identifier(valibotIdentifier),
+      j.identifier('intersect')
+    ),
+    [j.arrayExpression([schemaExp, ...inputArgs])]
+  );
+}

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/and/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/and/index.ts
@@ -1,0 +1,1 @@
+export * from './and';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/index.ts
@@ -1,3 +1,4 @@
+export * from './and';
 export * from './array';
 export * from './catchall';
 export * from './default';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
@@ -10,6 +10,7 @@ import {
 } from './constants';
 import { addToPipe } from './helpers';
 import {
+  transformAnd,
   transformArray as transformArrayMethod,
   transformCatchall,
   transformDeepPartial,
@@ -377,6 +378,8 @@ function toValibotMethodExp(
 ) {
   const args = [valibotIdentifier, schemaExp, inputArgs] as const;
   switch (zodMethodName) {
+    case 'and':
+      return transformAnd(...args);
     case 'array':
       return transformArrayMethod(...args);
     case 'catchall':


### PR DESCRIPTION
## Problem

The `@valibot/zod-to-valibot` codemod doesn't recognise the `and` chain method (it's missing from `ZOD_METHODS`), so it falls through to the unknown-method path and produces broken output where the method call is dropped and its argument is applied directly to the schema:

```ts
z.string().and(z.number())  // -> v.string()(v.number())
```

## Fix

`.and()` is zod's intersection method, so map it to valibot's [`v.intersect`](https://valibot.dev/api/intersect/) — mirroring how the existing `z.intersection(...)` schema and the `.or()` method (→ `v.union`) are handled:

```ts
z.string().and(z.number())  // -> v.intersect([v.string(), v.number()])
```

## Tests

Added an `and` fixture (primitive and object intersections). Full codemod suite passes (72 tests).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for zod’s `.and()` in the `@valibot/zod-to-valibot` codemod. Intersections now convert to `v.intersect([...])`, fixing the broken output where `.and()` was dropped.

**Bug Fixes**
- Map `.and()` to `v.intersect` and add it to `ZOD_METHODS` via a new `transformAnd` handler.
- Add fixture tests for primitive and object intersections.

<sup>Written for commit f79875755d322802b51d69a4d678f15953a26a4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/valibot/pull/1510?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

