### PR TITLE
fix: `~standard.validate` returns mutually exclusive result

### DIFF
--- a/library/src/utils/_getStandardProps/_getStandardProps.test.ts
+++ b/library/src/utils/_getStandardProps/_getStandardProps.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
-import { email, endsWith } from '../../actions/index.ts';
-import { pipe } from '../../methods/index.ts';
+import { checkAsync, email, endsWith, nonEmpty } from '../../actions/index.ts';
+import { pipe, pipeAsync } from '../../methods/index.ts';
 import { array, object, string } from '../../schemas/index.ts';
 import { deleteGlobalConfig, setGlobalConfig } from '../../storages/index.ts';
 import type {
@@ -57,6 +57,41 @@ describe('_getStandardProps', () => {
         },
       ],
     } satisfies StandardFailureResult);
+  });
+
+  test('should return mutually exclusive result (#1343)', () => {
+    // The Standard Schema contract requires a discriminated union: a failure
+    // result must expose only `issues`, never `value` or Valibot's `typed`.
+    const props = _getStandardProps(
+      object({ first: string(), second: pipe(string(), nonEmpty()) })
+    );
+
+    const failure = props.validate({ first: '', second: '' });
+    expect(failure).not.toHaveProperty('value');
+    expect(failure).not.toHaveProperty('typed');
+    expect(failure).toHaveProperty('issues');
+
+    const success = props.validate({ first: 'a', second: 'b' });
+    expect(success).not.toHaveProperty('issues');
+    expect(success).not.toHaveProperty('typed');
+    expect(success).toStrictEqual({ value: { first: 'a', second: 'b' } });
+  });
+
+  test('should return mutually exclusive result for async schema (#1343)', async () => {
+    const props = _getStandardProps(
+      pipeAsync(
+        string(),
+        checkAsync(async (input) => input.length > 0)
+      )
+    );
+
+    const failure = await props.validate('');
+    expect(failure).not.toHaveProperty('value');
+    expect(failure).not.toHaveProperty('typed');
+    expect(failure).toHaveProperty('issues');
+
+    const success = await props.validate('foo');
+    expect(success).toStrictEqual({ value: 'foo' });
   });
 
   test('should use global config', () => {

--- a/library/src/utils/_getStandardProps/_getStandardProps.ts
+++ b/library/src/utils/_getStandardProps/_getStandardProps.ts
@@ -5,12 +5,33 @@ import type {
   BaseSchemaAsync,
   InferInput,
   InferOutput,
+  OutputDataset,
   StandardProps,
   StandardResult,
 } from '../../types/index.ts';
 
 // Cache to avoid allocating a new StandardProps object on every `~standard` access
 const _standardCache = new WeakMap<object, StandardProps<unknown, unknown>>();
+
+/**
+ * Converts a Valibot output dataset into a Standard Schema result. The Standard
+ * Schema contract requires a discriminated union: a success result exposes only
+ * `value` and a failure result exposes only `issues`. Valibot's dataset always
+ * carries `typed` and `value`, so it must be mapped explicitly to avoid leaking
+ * `value`/`typed` next to `issues` on failure.
+ *
+ * @param dataset The Valibot output dataset.
+ *
+ * @returns The Standard Schema result.
+ */
+// @__NO_SIDE_EFFECTS__
+function _toStandardResult<TOutput>(
+  dataset: OutputDataset<TOutput, BaseIssue<unknown>>
+): StandardResult<TOutput> {
+  return dataset.issues
+    ? { issues: dataset.issues }
+    : { value: dataset.value };
+}
 
 /**
  * Returns the Standard Schema properties.
@@ -31,9 +52,10 @@ export function _getStandardProps<
       version: 1,
       vendor: 'valibot',
       validate(value) {
-        return context['~run']({ value }, getGlobalConfig()) as
-          | StandardResult<InferOutput<TSchema>>
-          | Promise<StandardResult<InferOutput<TSchema>>>;
+        const dataset = context['~run']({ value }, getGlobalConfig());
+        return dataset instanceof Promise
+          ? dataset.then(_toStandardResult)
+          : _toStandardResult(dataset);
       },
     };
     _standardCache.set(context, cached);


### PR DESCRIPTION
Closes #1343.

## Problem
The [Standard Schema](https://github.com/standard-schema/standard-schema) contract defines the validate result as a discriminated union — a success result exposes only `value`, a failure result exposes only `issues`:

```ts
type Result<T> = { value: T; issues?: undefined } | { issues: readonly Issue[] };
```

Valibot's `~standard.validate` returned the raw output dataset, which always carries `typed` and `value`. So a failed validation produced `{ value, typed, issues }` — leaking `value`/`typed` next to `issues` and breaking consumers that detect failure by the absence of `value`:

```ts
const schema = v.object({ first: v.string(), second: v.pipe(v.string(), v.nonEmpty()) });
schema['~standard'].validate({ first: '', second: '' });
// before: { value: {…}, typed: true, issues: [...] }   ❌ contract violation
// after:  { issues: [...] }                              ✅
```

## Fix
Map the output dataset to a proper `StandardResult` in `_getStandardProps`: return `{ issues }` when the dataset has issues, otherwise `{ value }`. The async (`Promise`) branch is mapped the same way.

## Tests
Added regression tests asserting the result is mutually exclusive for both sync and async schemas (failure has only `issues`; success has only `value`). The existing tests used `toMatchObject`, which is why the extra properties went unnoticed. Full library suite (build + test + lint + format) passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `~standard.validate` to return a correct discriminated union per Standard Schema: failures return only `issues`, successes return only `value`. Prevents leaking `value`/`typed` on failure and avoids breaking consumers that rely on the absence of `value`.

- **Bug Fixes**
  - Map the internal output dataset to `StandardResult` in `_getStandardProps` for both sync and async paths.
  - Add regression tests ensuring failures expose only `issues` and successes only `value`.

<sup>Written for commit dcdbceab83e8a22ebd7fac2a6242429e97e29ce9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/valibot/pull/1513?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

