### PR TITLE
fix(codemod): convert `z.brand` to `v.pipe(.., v.brand(..))`

### DIFF
--- a/codemod/zod-to-valibot/__testfixtures__/brand/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/brand/input.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+// Basic brand
+const Schema1 = z.string().brand("StationNumber");
+
+// Brand after validator chain
+const Schema2 = z.string().min(1).brand("NonEmptyId");
+
+// Brand on object schema
+const Schema3 = z.object({ id: z.string() }).brand("Entity");
+
+// Brand on linked schema
+const BaseSchema = z.number();
+const BrandedSchema = BaseSchema.brand("Count");

--- a/codemod/zod-to-valibot/__testfixtures__/brand/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/brand/output.ts
@@ -1,0 +1,14 @@
+import * as v from "valibot";
+
+// Basic brand
+const Schema1 = v.pipe(v.string(), v.brand("StationNumber"));
+
+// Brand after validator chain
+const Schema2 = v.pipe(v.string(), v.minLength(1), v.brand("NonEmptyId"));
+
+// Brand on object schema
+const Schema3 = v.pipe(v.object({ id: v.string() }), v.brand("Entity"));
+
+// Brand on linked schema
+const BaseSchema = v.number();
+const BrandedSchema = v.pipe(BaseSchema, v.brand("Count"));

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -9,6 +9,7 @@ defineTests(transform, [
   'array-schema',
   'array-validation-methods',
   'bigint-validation-methods',
+  'brand',
   'coerce-bigint-schema',
   'coerce-boolean-schema',
   'coerce-date-schema',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
@@ -135,6 +135,7 @@ export const ZOD_PROPERTIES = [
 
 export const ZOD_METHODS = [
   'array',
+  'brand',
   'catchall',
   'default',
   'deepPartial',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/brand/brand.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/brand/brand.ts
@@ -1,0 +1,20 @@
+import j from 'jscodeshift';
+import { addToPipe } from '../../helpers';
+
+export function transformBrand(
+  valibotIdentifier: string,
+  schemaExp: j.CallExpression | j.MemberExpression | j.Identifier,
+  args: j.CallExpression['arguments']
+) {
+  return addToPipe(
+    valibotIdentifier,
+    schemaExp,
+    j.callExpression(
+      j.memberExpression(
+        j.identifier(valibotIdentifier),
+        j.identifier('brand')
+      ),
+      args
+    )
+  );
+}

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/brand/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/brand/index.ts
@@ -1,0 +1,1 @@
+export * from './brand';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/methods/index.ts
@@ -1,4 +1,5 @@
 export * from './array';
+export * from './brand';
 export * from './catchall';
 export * from './default';
 export * from './deepPartial';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
@@ -11,6 +11,7 @@ import {
 import { addToPipe } from './helpers';
 import {
   transformArray as transformArrayMethod,
+  transformBrand,
   transformCatchall,
   transformDeepPartial,
   transformDefault,
@@ -379,6 +380,8 @@ function toValibotMethodExp(
   switch (zodMethodName) {
     case 'array':
       return transformArrayMethod(...args);
+    case 'brand':
+      return transformBrand(...args);
     case 'catchall':
       return transformCatchall(valibotIdentifier, schemaExp, inputArgs);
     case 'default':


### PR DESCRIPTION
Closes #1501.

## Problem
The `zod-to-valibot` codemod did not handle `.brand()`. The method name was not registered, so the `.brand("…")` call was left dangling on the converted schema, producing invalid output:

```ts
// input
z.string().brand("StationNumber");
// before (broken)
v.string()("StationNumber");
// expected
v.pipe(v.string(), v.brand("StationNumber"));
```

## Fix
Add a `brand` method handler that appends `v.brand(...)` to the schema's pipe via the existing `addToPipe` helper (same shape as the `transform` handler), register `brand` in `ZOD_METHODS`, and wire it into the method dispatch switch.

Handles the basic case, brands after a validator chain, brands on object schemas, and brands on linked schemas:

```ts
z.string().min(1).brand("NonEmptyId")    // → v.pipe(v.string(), v.minLength(1), v.brand("NonEmptyId"))
z.object({ id: z.string() }).brand("E")  // → v.pipe(v.object({ id: v.string() }), v.brand("E"))
```

## Tests
Adds a `brand` fixture (`__testfixtures__/brand`) covering the cases above and registers it in the test suite. Verified red without the fix (reproduces the `v.string()("…")` mangling) and green with it; the codemod package build + test suite passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `zod-to-valibot` codemod to correctly transform `z.brand()` into `v.pipe(..., v.brand(...))`, preventing invalid outputs like `v.string()("X")`.

- **Bug Fixes**
  - Added a `brand` method handler that appends `v.brand(...)` via `addToPipe`.
  - Registered `brand` in `ZOD_METHODS` and wired it into the method dispatcher.
  - Added tests covering basic, chained validators, object schemas, and linked schemas.

<sup>Written for commit 99922f04b1336b0172f06e1114a432d6172270c3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/open-circle/valibot/pull/1514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

