### PR TITLE
fix: handle z.brand() in zod-to-valibot codemod

### DIFF
--- a/codemod/zod-to-valibot/__testfixtures__/brand/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/brand/input.ts
@@ -1,0 +1,5 @@
+import { z } from "zod";
+
+const StationNumberSchema = z.string().brand("StationNumber");
+const IdSchema = z.number().brand("Id");
+const NonEmptyBrandSchema = z.string().min(1).brand("NonEmpty");

--- a/codemod/zod-to-valibot/__testfixtures__/brand/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/brand/output.ts
@@ -1,0 +1,5 @@
+import * as v from "valibot";
+
+const StationNumberSchema = v.pipe(v.string(), v.brand("StationNumber"));
+const IdSchema = v.pipe(v.number(), v.brand("Id"));
+const NonEmptyBrandSchema = v.pipe(v.string(), v.minLength(1), v.brand("NonEmpty"));

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -9,6 +9,7 @@ defineTests(transform, [
   'array-schema',
   'array-validation-methods',
   'bigint-validation-methods',
+  'brand',
   'coerce-bigint-schema',
   'coerce-boolean-schema',
   'coerce-date-schema',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
@@ -76,6 +76,7 @@ export const ZOD_VALUE_TYPE_SCHEMAS: readonly (typeof ZOD_SCHEMAS)[number][] = [
 export const ZOD_VALIDATORS = [
   'base64',
   'base64url',
+  'brand',
   'cidr',
   'cuid',
   'cuid2',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
@@ -78,6 +78,7 @@ import {
 import { ObjectModifier, ZodSchemaType } from './types';
 import {
   transformBase64,
+  transformBrand,
   transformCUID2,
   transformDateTime,
   transformDate as transformDateValidator,
@@ -260,6 +261,8 @@ function toValibotActionExp(
       return transformBase64(...args);
     case 'base64url':
       return transformUnimplemented(...args, 'base64url');
+    case 'brand':
+      return transformBrand(...args);
     case 'cidr':
       return transformUnimplemented(...args, 'cidr');
     case 'cuid':

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/brand/brand.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/brand/brand.ts
@@ -1,0 +1,11 @@
+import j from 'jscodeshift';
+
+export function transformBrand(
+  valibotIdentifier: string,
+  args: j.CallExpression['arguments']
+) {
+  return j.callExpression(
+    j.memberExpression(j.identifier(valibotIdentifier), j.identifier('brand')),
+    args
+  );
+}

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/brand/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/brand/index.ts
@@ -1,0 +1,1 @@
+export * from './brand';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/index.ts
@@ -1,4 +1,5 @@
 export * from './base64';
+export * from './brand';
 export * from './cuid2';
 export * from './date';
 export * from './datetime';


### PR DESCRIPTION
Fixes #1501

The zod-to-valibot codemod didn't recognize `.brand()`, so `z.string().brand("StationNumber")` was emitted as `v.string()("StationNumber")` — a schema called as a function, which doesn't compile.

`brand` is now handled as a validator, mapping `z.<schema>().brand(name)` to `v.pipe(v.<schema>(), v.brand(name))`:

- added `brand` to `ZOD_VALIDATORS` and a `transformBrand` that emits `v.brand(...)`
- added a `brand` test fixture (string and number brands, plus one chained with `.min()`)

This covers the runtime-argument form `.brand("X")` from the issue. The type-only form `.brand<"X">()` carries no runtime value and the validator transform only receives runtime arguments, so it's left out of scope here.

Tested with `vitest` (72 passing, including the new `brand` fixture).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting Zod branded schemas to Valibot branded schemas in the codemod.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->