### PR TITLE
fix: cache word-count segmenter for non-primitive locales

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix word count actions to cache the `Intl.Segmenter` for non-primitive locales, preventing it from being recreated on every `words`, `minWords`, `maxWords` and `notWords` validation (pull request #1521)
+
 ## v1.4.1 (May 24, 2026)
 
 - Fix `intersect` schema to infer correct input and output types for non-tuple array options instead of `never` (pull request #1478)

--- a/library/src/utils/_getWordCount/_getWordCount.test.ts
+++ b/library/src/utils/_getWordCount/_getWordCount.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { _getWordCount } from './_getWordCount.ts';
 
 describe('_getWordCount', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   test('should return word count', () => {
     expect(_getWordCount('en', '')).toBe(0);
     expect(_getWordCount('en', 'h')).toBe(1);
@@ -9,6 +13,27 @@ describe('_getWordCount', () => {
     expect(_getWordCount('en', 'hello world')).toBe(2);
     expect(_getWordCount('en', '🧑🏻‍💻')).toBe(0);
     expect(_getWordCount('th', 'สวัสดี')).toBe(1);
+  });
+
+  test('should cache segmenter for non-primitive locales', () => {
+    const OriginalSegmenter = Intl.Segmenter;
+    const SegmenterSpy = vi
+      .spyOn(Intl, 'Segmenter')
+      .mockImplementation(function (locales, options) {
+        return new OriginalSegmenter(locales, options);
+      });
+
+    // An array of locales and an `Intl.Locale` object are non-primitive values
+    // with a fresh reference on each call, so they must be cached by a stable
+    // key instead of by reference.
+    _getWordCount(['ja-JP'], 'foo bar');
+    _getWordCount(['ja-JP'], 'baz qux');
+    _getWordCount(new Intl.Locale('ja-JP'), 'foo bar');
+    _getWordCount(new Intl.Locale('ja-JP'), 'baz qux');
+
+    // The segmenter for `ja-JP` should only be created once, even though four
+    // distinct (but equal) locale arguments were passed.
+    expect(SegmenterSpy).toHaveBeenCalledTimes(1);
   });
 
   // TODO: This test is failing in CI, but works locally 😑

--- a/library/src/utils/_getWordCount/_getWordCount.ts
+++ b/library/src/utils/_getWordCount/_getWordCount.ts
@@ -1,4 +1,4 @@
-let store: Map<Intl.LocalesArgument, Intl.Segmenter>;
+let store: Map<string, Intl.Segmenter>;
 
 /**
  * Returns the word count of the input.
@@ -18,10 +18,17 @@ export function _getWordCount(
   if (!store) {
     store = new Map();
   }
-  if (!store.get(locales)) {
-    store.set(locales, new Intl.Segmenter(locales, { granularity: 'word' }));
+  // Hint: We use a stable string key instead of `locales` directly, because
+  // `Intl.LocalesArgument` is often a non-primitive value (an array or an
+  // `Intl.Locale` object). Such values are compared by reference in a `Map`,
+  // which would defeat the cache and recreate the segmenter on every call.
+  const key = String(locales);
+  let segmenter = store.get(key);
+  if (!segmenter) {
+    segmenter = new Intl.Segmenter(locales, { granularity: 'word' });
+    store.set(key, segmenter);
   }
-  const segments = store.get(locales)!.segment(input);
+  const segments = segmenter.segment(input);
   let count = 0;
   for (const segment of segments) {
     if (segment.isWordLike) {


### PR DESCRIPTION
The internal \`_getWordCount\` util caches the \`Intl.Segmenter\` in a \`Map\` keyed by the raw \`locales\` argument:

\`\`\`ts
if (!store.get(locales)) {
  store.set(locales, new Intl.Segmenter(locales, { granularity: 'word' }));
}
\`\`\`

But \`Intl.LocalesArgument\` is commonly a **non-primitive** value — an array of locales (e.g. \`['en-US', 'de']\`) or an \`Intl.Locale\` object. Those are compared by reference in a \`Map\`, so a fresh-but-equal argument on each call always misses the cache and a brand-new \`Intl.Segmenter\` is constructed on **every** \`words\` / \`minWords\` / \`maxWords\` / \`notWords\` validation. The cache only ever hits for plain string locales.

### Fix
Key the cache by \`String(locales)\` (a stable BCP-47 string for strings, arrays and \`Intl.Locale\` objects) so equal locale arguments reuse the same segmenter. Counting behavior is unchanged.

### Test
Added a test that spies on \`Intl.Segmenter\` and passes the same locale as both an array and an \`Intl.Locale\` across four calls. Before the fix the constructor runs 4 times; after, exactly once.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved word counting for actions that validate word counts by reusing the same segmentation instance for equivalent locale inputs, reducing inconsistent results across repeated validations.
* **Tests**
  * Updated the word-count test suite to restore mocks after each test.
  * Added coverage to ensure locale-equivalent inputs (arrays and locale objects) reuse cached segmentation so it’s created only once.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->