### PR TITLE
fix: handle keys that collide with Object.prototype in flatten and merge

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to the library will be documented in this file.
 ## vX.X.X (Month DD, YYYY)
 
 - Fix word count actions to cache the `Intl.Segmenter` for non-primitive locales, preventing it from being recreated on every `words`, `minWords`, `maxWords` and `notWords` validation (pull request #1521)
+- Fix `flatten` method to handle issue path keys that collide with `Object.prototype` members like `toString` instead of throwing a `TypeError` (pull request #1522)
+- Fix `intersect` schema to merge object keys that collide with `Object.prototype` members like `toString` instead of failing to merge them (pull request #1522)
 
 ## v1.4.1 (May 24, 2026)
 

--- a/library/src/methods/flatten/flatten.test.ts
+++ b/library/src/methods/flatten/flatten.test.ts
@@ -219,6 +219,70 @@ describe('flatten', () => {
     });
   });
 
+  test('should handle keys that collide with object prototype', () => {
+    // Issue paths can contain keys (e.g. via `record`) that collide with
+    // `Object.prototype` members like `toString`. These must be treated as
+    // regular nested keys instead of resolving to the inherited member.
+    const keys = [
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+    ] as const;
+    const issues = keys.map(
+      (key): NumberIssue => ({
+        ...commonIssueInfo,
+        kind: 'schema',
+        type: 'number',
+        input: 'foo',
+        expected: 'number',
+        received: '"foo"',
+        message: 'Invalid type: Expected number but received "foo"',
+        path: [
+          {
+            type: 'object',
+            origin: 'value',
+            input: { [key]: 'foo' },
+            key,
+            value: 'foo',
+          } satisfies ObjectPathItem,
+        ],
+      })
+    ) as [NumberIssue, ...NumberIssue[]];
+    const flatErrors = flatten(issues);
+    for (const key of keys) {
+      expect(flatErrors.nested?.[key]).toEqual([
+        'Invalid type: Expected number but received "foo"',
+      ]);
+    }
+  });
+
+  test('should accumulate messages for prototype-colliding keys', () => {
+    const issue = (message: string): NumberIssue => ({
+      ...commonIssueInfo,
+      kind: 'schema',
+      type: 'number',
+      input: 'foo',
+      expected: 'number',
+      received: '"foo"',
+      message,
+      path: [
+        {
+          type: 'object',
+          origin: 'value',
+          input: { toString: 'foo' },
+          key: 'toString',
+          value: 'foo',
+        } satisfies ObjectPathItem,
+      ],
+    });
+    expect(flatten([issue('first'), issue('second')])).toStrictEqual({
+      nested: {
+        toString: ['first', 'second'],
+      },
+    });
+  });
+
   test('should return single other error', () => {
     const otherIssue: NumberIssue = {
       ...commonIssueInfo,

--- a/library/src/methods/flatten/flatten.ts
+++ b/library/src/methods/flatten/flatten.ts
@@ -101,7 +101,7 @@ export function flatten(
           // @ts-expect-error
           flatErrors.nested = {};
         }
-        if (flatErrors.nested![dotPath]) {
+        if (Object.prototype.hasOwnProperty.call(flatErrors.nested, dotPath)) {
           flatErrors.nested![dotPath]!.push(issue.message);
         } else {
           // @ts-expect-error

--- a/library/src/schemas/intersect/utils/_merge/_merge.test.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.test.ts
@@ -36,7 +36,7 @@ describe('_merge', () => {
     test('for keys colliding with object prototype', () => {
       // Own keys that collide with `Object.prototype` members must be merged
       // as regular entries instead of resolving to the inherited member via
-      // the `in` operator (related to GHSA-5qjj-4xww-7phc).
+      // the `in` operator.
       expect(_merge({}, { toString: 'foo' })).toStrictEqual({
         value: { toString: 'foo' },
       });

--- a/library/src/schemas/intersect/utils/_merge/_merge.test.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.test.ts
@@ -33,6 +33,21 @@ describe('_merge', () => {
       });
     });
 
+    test('for keys colliding with object prototype', () => {
+      // Own keys that collide with `Object.prototype` members must be merged
+      // as regular entries instead of resolving to the inherited member via
+      // the `in` operator (related to GHSA-5qjj-4xww-7phc).
+      expect(_merge({}, { toString: 'foo' })).toStrictEqual({
+        value: { toString: 'foo' },
+      });
+      expect(_merge({ valueOf: 1 }, { valueOf: 1 })).toStrictEqual({
+        value: { valueOf: 1 },
+      });
+      expect(
+        _merge({ hasOwnProperty: 1 }, { hasOwnProperty: '1' })
+      ).toStrictEqual({ issue: true });
+    });
+
     test('for valid frozen object', () => {
       expect(_merge(Object.freeze({ key: 1 }), { key: 1 })).toStrictEqual({
         value: { key: 1 },

--- a/library/src/schemas/intersect/utils/_merge/_merge.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.ts
@@ -38,8 +38,7 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
 
       // Deeply merge entries of `value2` into `nextValue`
       for (const key in value2) {
-        // @ts-expect-error
-        if (key in value1) {
+        if (Object.prototype.hasOwnProperty.call(value1, key)) {
           // @ts-expect-error
           const dataset = _merge(value1[key], value2[key]);
 


### PR DESCRIPTION
## Summary

Two related fixes for handling object keys that collide with `Object.prototype` members (e.g. `toString`, `valueOf`, `hasOwnProperty`).

### `flatten`

`flatten` stored nested errors in a plain object and tested entry existence by truthiness:

```ts
flatErrors.nested = {};
// ...
if (flatErrors.nested![dotPath]) {
  flatErrors.nested![dotPath]!.push(issue.message);
}
```

When an issue path key equals an inherited `Object.prototype` member (which can happen with `record` schemas — `{ toString: ... }` is a valid own key), the truthiness check resolved to the inherited function and `flatten` called `.push` on it, throwing `TypeError: flatErrors.nested[dotPath].push is not a function`. Now it uses an own-property check, so such keys are treated as regular nested keys.

```ts
v.flatten(v.safeParse(v.record(v.string(), v.number()), { toString: 'x' }).issues);
// before: throws TypeError
// after:  { nested: { toString: ['Invalid type: Expected number but received "x"'] } }
```

### `intersect` (`_merge`)

The internal `_merge` util used `key in value1` to decide whether to deep-merge an entry. The `in` operator also matches inherited `Object.prototype` members, so an own key such as `toString` present in only one side resolved to the inherited member and made the merge fail:

```ts
v.safeParse(v.intersect([v.object({}), v.record(v.string(), v.string())]), { toString: 'x' });
// before: rejected (could not merge)
// after:  { toString: 'x' }
```

Both now use `Object.prototype.hasOwnProperty.call(...)`, consistent with the existing `_isValidObjectKey` helper.

## Test plan

- Added regression tests covering prototype-colliding keys (`toString`, `valueOf`, `hasOwnProperty`, `constructor`) for both `flatten` and `_merge`.
- `pnpm test`, `tsc --noEmit`, ESLint and Prettier pass on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error flattening so keys like `toString`, `valueOf`, `hasOwnProperty`, and `constructor` are handled as normal nested keys.
  * Improved merging behavior so object keys that match built-in prototype members are merged correctly instead of causing failures.
  * When multiple messages target the same key, they now combine into a single array of messages as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->