### PR TITLE
fix: handle object keys that collide with Object.prototype in object schemas

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the library will be documented in this file.
 
+## vX.X.X (Month DD, YYYY)
+
+- Fix `strictObject` and `strictObjectAsync` to reject unknown input keys that collide with `Object.prototype` members like `toString` instead of accepting them silently (pull request #1523)
+- Fix `looseObject`, `looseObjectAsync`, `objectWithRest` and `objectWithRestAsync` to pass through or apply `rest` to input keys that collide with `Object.prototype` members instead of skipping them (pull request #1523)
+
 ## v1.4.2 (June 28, 2026)
 
 - Fix word count actions to cache the `Intl.Segmenter` for non-primitive locales, preventing it from being recreated on every `words`, `minWords`, `maxWords` and `notWords` validation (pull request #1521)

--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the library will be documented in this file.
 - Fix `literal` schema and `value`, `values`, `notValue` and `notValues` actions to treat `NaN` as equal to itself (pull request #1573)
 - Fix `intersect` schema to merge matching `NaN` values and invalid dates (pull request #1573)
 - Fix `cache` and `cacheAsync` methods to clone the issues of a cached dataset, preventing parent schemas from adding their path item to the same issue on every cache hit (pull request #1620)
+- Fix `strictObject`, `looseObject`, `objectWithRest` and their async variants to correctly handle unknown input keys that collide with `Object.prototype` members (pull request #1523)
 
 ## v1.4.2 (June 28, 2026)
 

--- a/library/src/schemas/looseObject/looseObject.test.ts
+++ b/library/src/schemas/looseObject/looseObject.test.ts
@@ -672,4 +672,16 @@ describe('looseObject', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should pass through keys colliding with the object prototype', () => {
+    const schema = looseObject({ key: string() });
+
+    test('for unknown key named like an object prototype member', () => {
+      const input = { key: 'foo', toString: 'bar' };
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: { key: 'foo', toString: 'bar' },
+      });
+    });
+  });
 });

--- a/library/src/schemas/looseObject/looseObject.test.ts
+++ b/library/src/schemas/looseObject/looseObject.test.ts
@@ -672,4 +672,46 @@ describe('looseObject', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should pass through keys colliding with the object prototype', () => {
+    const schema = looseObject({ key: string() });
+
+    test.each(['toString', 'valueOf', 'hasOwnProperty'])(
+      'for unknown %s key',
+      (key) => {
+        const input = { key: 'foo', [key]: 'bar' };
+        expect(schema['~run']({ value: input }, {})).toStrictEqual({
+          typed: true,
+          value: { key: 'foo', [key]: 'bar' },
+        });
+      }
+    );
+  });
+
+  describe('should parse declared keys colliding with the object prototype', () => {
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', (key) => {
+      const schema = looseObject({ [key]: string() });
+      const input = { [key]: 'foo' };
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: input,
+      });
+    });
+  });
+
+  test('without including excluded unknown keys', () => {
+    const schema = looseObject({ key: string() });
+    const input = JSON.parse(
+      '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
+    );
+    const dataset = schema['~run']({ value: input }, {});
+    expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
+    expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
+  });
 });

--- a/library/src/schemas/looseObject/looseObject.test.ts
+++ b/library/src/schemas/looseObject/looseObject.test.ts
@@ -73,6 +73,37 @@ describe('looseObject', () => {
         { key1: 'foo', key2: 123, other1: 'bar', other2: null },
       ]);
     });
+
+    test.each(['toString', 'valueOf', 'hasOwnProperty'])(
+      'for unknown %s key',
+      (key) => {
+        const schema = looseObject({ key: string() });
+        const input = { key: 'foo', [key]: 'bar' };
+        expectNoSchemaIssue(schema, [input]);
+      }
+    );
+
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', (key) => {
+      const schema = looseObject({ [key]: string() });
+      const input = { [key]: 'foo' };
+      expectNoSchemaIssue(schema, [input]);
+    });
+
+    test('without including excluded unknown keys', () => {
+      const schema = looseObject({ key: string() });
+      const input = JSON.parse(
+        '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
+      );
+      const dataset = schema['~run']({ value: input }, {});
+      expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
+      expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
+    });
   });
 
   describe('should return dataset with issues', () => {
@@ -671,47 +702,5 @@ describe('looseObject', () => {
         ],
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
-  });
-
-  describe('should pass through keys colliding with the object prototype', () => {
-    const schema = looseObject({ key: string() });
-
-    test.each(['toString', 'valueOf', 'hasOwnProperty'])(
-      'for unknown %s key',
-      (key) => {
-        const input = { key: 'foo', [key]: 'bar' };
-        expect(schema['~run']({ value: input }, {})).toStrictEqual({
-          typed: true,
-          value: { key: 'foo', [key]: 'bar' },
-        });
-      }
-    );
-  });
-
-  describe('should parse declared keys colliding with the object prototype', () => {
-    test.each([
-      'toString',
-      'valueOf',
-      'hasOwnProperty',
-      'constructor',
-      'prototype',
-    ])('for declared %s key', (key) => {
-      const schema = looseObject({ [key]: string() });
-      const input = { [key]: 'foo' };
-      expect(schema['~run']({ value: input }, {})).toStrictEqual({
-        typed: true,
-        value: input,
-      });
-    });
-  });
-
-  test('without including excluded unknown keys', () => {
-    const schema = looseObject({ key: string() });
-    const input = JSON.parse(
-      '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
-    );
-    const dataset = schema['~run']({ value: input }, {});
-    expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
-    expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
   });
 });

--- a/library/src/schemas/looseObject/looseObject.ts
+++ b/library/src/schemas/looseObject/looseObject.ts
@@ -205,7 +205,10 @@ export function looseObject(
         // Hint: We exclude specific keys for security reasons
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (_isValidObjectKey(input, key) && !(key in this.entries)) {
+            if (
+              _isValidObjectKey(input, key) &&
+              !Object.prototype.hasOwnProperty.call(this.entries, key)
+            ) {
               // @ts-expect-error
               dataset.value[key] = input[key];
             }

--- a/library/src/schemas/looseObject/looseObject.ts
+++ b/library/src/schemas/looseObject/looseObject.ts
@@ -203,7 +203,10 @@ export function looseObject(
         // Hint: We exclude specific keys for security reasons
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (_isValidObjectKey(input, key) && !(key in this.entries)) {
+            if (
+              _isValidObjectKey(input, key) &&
+              !Object.prototype.hasOwnProperty.call(this.entries, key)
+            ) {
               // @ts-expect-error
               dataset.value[key] = input[key];
             }

--- a/library/src/schemas/looseObject/looseObjectAsync.test.ts
+++ b/library/src/schemas/looseObject/looseObjectAsync.test.ts
@@ -857,4 +857,16 @@ describe('looseObjectAsync', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should pass through keys colliding with the object prototype', () => {
+    const schema = looseObjectAsync({ key: string() });
+
+    test('for unknown key named like an object prototype member', async () => {
+      const input = { key: 'foo', toString: 'bar' };
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: { key: 'foo', toString: 'bar' },
+      });
+    });
+  });
 });

--- a/library/src/schemas/looseObject/looseObjectAsync.test.ts
+++ b/library/src/schemas/looseObject/looseObjectAsync.test.ts
@@ -84,6 +84,37 @@ describe('looseObjectAsync', () => {
         [{ key1: 'foo', key2: 123, other1: 'bar', other2: null }]
       );
     });
+
+    test.each(['toString', 'valueOf', 'hasOwnProperty'])(
+      'for unknown %s key',
+      async (key) => {
+        const schema = looseObjectAsync({ key: string() });
+        const input = { key: 'foo', [key]: 'bar' };
+        await expectNoSchemaIssueAsync(schema, [input]);
+      }
+    );
+
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', async (key) => {
+      const schema = looseObjectAsync({ [key]: string() });
+      const input = { [key]: 'foo' };
+      await expectNoSchemaIssueAsync(schema, [input]);
+    });
+
+    test('without including excluded unknown keys', async () => {
+      const schema = looseObjectAsync({ key: string() });
+      const input = JSON.parse(
+        '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
+      );
+      const dataset = await schema['~run']({ value: input }, {});
+      expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
+      expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
+    });
   });
 
   describe('should return dataset with issues', () => {
@@ -856,47 +887,5 @@ describe('looseObjectAsync', () => {
         ],
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
-  });
-
-  describe('should pass through keys colliding with the object prototype', () => {
-    const schema = looseObjectAsync({ key: string() });
-
-    test.each(['toString', 'valueOf', 'hasOwnProperty'])(
-      'for unknown %s key',
-      async (key) => {
-        const input = { key: 'foo', [key]: 'bar' };
-        expect(await schema['~run']({ value: input }, {})).toStrictEqual({
-          typed: true,
-          value: { key: 'foo', [key]: 'bar' },
-        });
-      }
-    );
-  });
-
-  describe('should parse declared keys colliding with the object prototype', () => {
-    test.each([
-      'toString',
-      'valueOf',
-      'hasOwnProperty',
-      'constructor',
-      'prototype',
-    ])('for declared %s key', async (key) => {
-      const schema = looseObjectAsync({ [key]: string() });
-      const input = { [key]: 'foo' };
-      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
-        typed: true,
-        value: input,
-      });
-    });
-  });
-
-  test('without including excluded unknown keys', async () => {
-    const schema = looseObjectAsync({ key: string() });
-    const input = JSON.parse(
-      '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
-    );
-    const dataset = await schema['~run']({ value: input }, {});
-    expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
-    expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
   });
 });

--- a/library/src/schemas/looseObject/looseObjectAsync.test.ts
+++ b/library/src/schemas/looseObject/looseObjectAsync.test.ts
@@ -857,4 +857,46 @@ describe('looseObjectAsync', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should pass through keys colliding with the object prototype', () => {
+    const schema = looseObjectAsync({ key: string() });
+
+    test.each(['toString', 'valueOf', 'hasOwnProperty'])(
+      'for unknown %s key',
+      async (key) => {
+        const input = { key: 'foo', [key]: 'bar' };
+        expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+          typed: true,
+          value: { key: 'foo', [key]: 'bar' },
+        });
+      }
+    );
+  });
+
+  describe('should parse declared keys colliding with the object prototype', () => {
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', async (key) => {
+      const schema = looseObjectAsync({ [key]: string() });
+      const input = { [key]: 'foo' };
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: input,
+      });
+    });
+  });
+
+  test('without including excluded unknown keys', async () => {
+    const schema = looseObjectAsync({ key: string() });
+    const input = JSON.parse(
+      '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
+    );
+    const dataset = await schema['~run']({ value: input }, {});
+    expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
+    expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
+  });
 });

--- a/library/src/schemas/looseObject/looseObjectAsync.ts
+++ b/library/src/schemas/looseObject/looseObjectAsync.ts
@@ -226,7 +226,10 @@ export function looseObjectAsync(
         // Hint: We exclude specific keys for security reasons
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (_isValidObjectKey(input, key) && !(key in this.entries)) {
+            if (
+              _isValidObjectKey(input, key) &&
+              !Object.prototype.hasOwnProperty.call(this.entries, key)
+            ) {
               // @ts-expect-error
               dataset.value[key] = input[key];
             }

--- a/library/src/schemas/looseObject/looseObjectAsync.ts
+++ b/library/src/schemas/looseObject/looseObjectAsync.ts
@@ -224,7 +224,10 @@ export function looseObjectAsync(
         // Hint: We exclude specific keys for security reasons
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (_isValidObjectKey(input, key) && !(key in this.entries)) {
+            if (
+              _isValidObjectKey(input, key) &&
+              !Object.prototype.hasOwnProperty.call(this.entries, key)
+            ) {
               // @ts-expect-error
               dataset.value[key] = input[key];
             }

--- a/library/src/schemas/objectWithRest/objectWithRest.test.ts
+++ b/library/src/schemas/objectWithRest/objectWithRest.test.ts
@@ -805,4 +805,44 @@ describe('objectWithRest', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should apply rest to keys colliding with the object prototype', () => {
+    const schema = objectWithRest({ key: string() }, number());
+
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for unknown key named like an object prototype member', () => {
+      const input = { key: 'foo', toString: 'bar' };
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: input,
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'number',
+            input: 'bar',
+            expected: 'number',
+            received: '"bar"',
+            path: [
+              {
+                type: 'object',
+                origin: 'value',
+                input,
+                key: 'toString',
+                value: input.toString,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+  });
 });

--- a/library/src/schemas/objectWithRest/objectWithRest.test.ts
+++ b/library/src/schemas/objectWithRest/objectWithRest.test.ts
@@ -805,4 +805,83 @@ describe('objectWithRest', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should apply rest to keys colliding with the object prototype', () => {
+    const schema = objectWithRest({ key: string() }, number());
+
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test.each(['toString', 'valueOf', 'hasOwnProperty'])(
+      'for unknown %s key',
+      (key) => {
+        const input = { key: 'foo', [key]: 'bar' };
+        expect(schema['~run']({ value: input }, {})).toStrictEqual({
+          typed: false,
+          value: input,
+          issues: [
+            {
+              ...baseInfo,
+              kind: 'schema',
+              type: 'number',
+              input: 'bar',
+              expected: 'number',
+              received: '"bar"',
+              path: [
+                {
+                  type: 'object',
+                  origin: 'value',
+                  input,
+                  key,
+                  value: input[key],
+                },
+              ],
+            },
+          ],
+        } satisfies FailureDataset<InferIssue<typeof schema>>);
+      }
+    );
+  });
+
+  describe('should parse declared keys colliding with the object prototype', () => {
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', (key) => {
+      const schema = objectWithRest({ [key]: string() }, number());
+      const input = { [key]: 'foo' };
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: input,
+      });
+    });
+  });
+
+  test('without including excluded unknown keys', () => {
+    const schema = objectWithRest({ key: string() }, number());
+    const input = JSON.parse(
+      '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
+    );
+    const dataset = schema['~run']({ value: input }, {});
+    expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
+    expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
+  });
+
+  test('for valid rest keys colliding with the object prototype', () => {
+    const schema = objectWithRest({ key: string() }, number());
+    const input = { key: 'foo', toString: 1, valueOf: 2, hasOwnProperty: 3 };
+    expect(schema['~run']({ value: input }, {})).toStrictEqual({
+      typed: true,
+      value: input,
+    });
+  });
 });

--- a/library/src/schemas/objectWithRest/objectWithRest.test.ts
+++ b/library/src/schemas/objectWithRest/objectWithRest.test.ts
@@ -79,6 +79,40 @@ describe('objectWithRest', () => {
         [{ key1: 'foo', key2: 123, other: true }]
       );
     });
+
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', (key) => {
+      const schema = objectWithRest({ [key]: string() }, number());
+      const input = { [key]: 'foo' };
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: input,
+      });
+    });
+
+    test('without including excluded unknown keys', () => {
+      const schema = objectWithRest({ key: string() }, number());
+      const input = JSON.parse(
+        '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
+      );
+      const dataset = schema['~run']({ value: input }, {});
+      expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
+      expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
+    });
+
+    test('for valid rest keys colliding with the object prototype', () => {
+      const schema = objectWithRest({ key: string() }, number());
+      const input = { key: 'foo', toString: 1, valueOf: 2, hasOwnProperty: 3 };
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: input,
+      });
+    });
   });
 
   describe('should return dataset with issues', () => {
@@ -804,23 +838,11 @@ describe('objectWithRest', () => {
         ],
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
-  });
-
-  describe('should apply rest to keys colliding with the object prototype', () => {
-    const schema = objectWithRest({ key: string() }, number());
-
-    const baseInfo = {
-      message: expect.any(String),
-      requirement: undefined,
-      issues: undefined,
-      lang: undefined,
-      abortEarly: undefined,
-      abortPipeEarly: undefined,
-    };
 
     test.each(['toString', 'valueOf', 'hasOwnProperty'])(
       'for unknown %s key',
       (key) => {
+        const schema = objectWithRest({ key: string() }, number());
         const input = { key: 'foo', [key]: 'bar' };
         expect(schema['~run']({ value: input }, {})).toStrictEqual({
           typed: false,
@@ -847,41 +869,5 @@ describe('objectWithRest', () => {
         } satisfies FailureDataset<InferIssue<typeof schema>>);
       }
     );
-  });
-
-  describe('should parse declared keys colliding with the object prototype', () => {
-    test.each([
-      'toString',
-      'valueOf',
-      'hasOwnProperty',
-      'constructor',
-      'prototype',
-    ])('for declared %s key', (key) => {
-      const schema = objectWithRest({ [key]: string() }, number());
-      const input = { [key]: 'foo' };
-      expect(schema['~run']({ value: input }, {})).toStrictEqual({
-        typed: true,
-        value: input,
-      });
-    });
-  });
-
-  test('without including excluded unknown keys', () => {
-    const schema = objectWithRest({ key: string() }, number());
-    const input = JSON.parse(
-      '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
-    );
-    const dataset = schema['~run']({ value: input }, {});
-    expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
-    expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
-  });
-
-  test('for valid rest keys colliding with the object prototype', () => {
-    const schema = objectWithRest({ key: string() }, number());
-    const input = { key: 'foo', toString: 1, valueOf: 2, hasOwnProperty: 3 };
-    expect(schema['~run']({ value: input }, {})).toStrictEqual({
-      typed: true,
-      value: input,
-    });
   });
 });

--- a/library/src/schemas/objectWithRest/objectWithRest.ts
+++ b/library/src/schemas/objectWithRest/objectWithRest.ts
@@ -228,7 +228,10 @@ export function objectWithRest(
         // Hint: We exclude specific keys for security reasons
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (_isValidObjectKey(input, key) && !(key in this.entries)) {
+            if (
+              _isValidObjectKey(input, key) &&
+              !Object.prototype.hasOwnProperty.call(this.entries, key)
+            ) {
               const valueDataset = this.rest['~run'](
                 // @ts-expect-error
                 { value: input[key] },

--- a/library/src/schemas/objectWithRest/objectWithRest.ts
+++ b/library/src/schemas/objectWithRest/objectWithRest.ts
@@ -226,7 +226,10 @@ export function objectWithRest(
         // Hint: We exclude specific keys for security reasons
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (_isValidObjectKey(input, key) && !(key in this.entries)) {
+            if (
+              _isValidObjectKey(input, key) &&
+              !Object.prototype.hasOwnProperty.call(this.entries, key)
+            ) {
               const valueDataset = this.rest['~run'](
                 // @ts-expect-error
                 { value: input[key] },

--- a/library/src/schemas/objectWithRest/objectWithRestAsync.test.ts
+++ b/library/src/schemas/objectWithRest/objectWithRestAsync.test.ts
@@ -995,4 +995,44 @@ describe('objectWithRestAsync', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should apply rest to keys colliding with the object prototype', () => {
+    const schema = objectWithRestAsync({ key: string() }, number());
+
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for unknown key named like an object prototype member', async () => {
+      const input = { key: 'foo', toString: 'bar' };
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: input,
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'number',
+            input: 'bar',
+            expected: 'number',
+            received: '"bar"',
+            path: [
+              {
+                type: 'object',
+                origin: 'value',
+                input,
+                key: 'toString',
+                value: input.toString,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+  });
 });

--- a/library/src/schemas/objectWithRest/objectWithRestAsync.test.ts
+++ b/library/src/schemas/objectWithRest/objectWithRestAsync.test.ts
@@ -995,4 +995,83 @@ describe('objectWithRestAsync', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should apply rest to keys colliding with the object prototype', () => {
+    const schema = objectWithRestAsync({ key: string() }, number());
+
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test.each(['toString', 'valueOf', 'hasOwnProperty'])(
+      'for unknown %s key',
+      async (key) => {
+        const input = { key: 'foo', [key]: 'bar' };
+        expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+          typed: false,
+          value: input,
+          issues: [
+            {
+              ...baseInfo,
+              kind: 'schema',
+              type: 'number',
+              input: 'bar',
+              expected: 'number',
+              received: '"bar"',
+              path: [
+                {
+                  type: 'object',
+                  origin: 'value',
+                  input,
+                  key,
+                  value: input[key],
+                },
+              ],
+            },
+          ],
+        } satisfies FailureDataset<InferIssue<typeof schema>>);
+      }
+    );
+  });
+
+  describe('should parse declared keys colliding with the object prototype', () => {
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', async (key) => {
+      const schema = objectWithRestAsync({ [key]: string() }, number());
+      const input = { [key]: 'foo' };
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: input,
+      });
+    });
+  });
+
+  test('without including excluded unknown keys', async () => {
+    const schema = objectWithRestAsync({ key: string() }, number());
+    const input = JSON.parse(
+      '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
+    );
+    const dataset = await schema['~run']({ value: input }, {});
+    expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
+    expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
+  });
+
+  test('for valid rest keys colliding with the object prototype', async () => {
+    const schema = objectWithRestAsync({ key: string() }, number());
+    const input = { key: 'foo', toString: 1, valueOf: 2, hasOwnProperty: 3 };
+    expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+      typed: true,
+      value: input,
+    });
+  });
 });

--- a/library/src/schemas/objectWithRest/objectWithRestAsync.test.ts
+++ b/library/src/schemas/objectWithRest/objectWithRestAsync.test.ts
@@ -87,6 +87,40 @@ describe('objectWithRestAsync', () => {
         [{ key1: 'foo', key2: 123, other: true }]
       );
     });
+
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', async (key) => {
+      const schema = objectWithRestAsync({ [key]: string() }, number());
+      const input = { [key]: 'foo' };
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: input,
+      });
+    });
+
+    test('without including excluded unknown keys', async () => {
+      const schema = objectWithRestAsync({ key: string() }, number());
+      const input = JSON.parse(
+        '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
+      );
+      const dataset = await schema['~run']({ value: input }, {});
+      expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
+      expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
+    });
+
+    test('for valid rest keys colliding with the object prototype', async () => {
+      const schema = objectWithRestAsync({ key: string() }, number());
+      const input = { key: 'foo', toString: 1, valueOf: 2, hasOwnProperty: 3 };
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: input,
+      });
+    });
   });
 
   describe('should return dataset with issues', () => {
@@ -994,23 +1028,11 @@ describe('objectWithRestAsync', () => {
         ],
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
-  });
-
-  describe('should apply rest to keys colliding with the object prototype', () => {
-    const schema = objectWithRestAsync({ key: string() }, number());
-
-    const baseInfo = {
-      message: expect.any(String),
-      requirement: undefined,
-      issues: undefined,
-      lang: undefined,
-      abortEarly: undefined,
-      abortPipeEarly: undefined,
-    };
 
     test.each(['toString', 'valueOf', 'hasOwnProperty'])(
       'for unknown %s key',
       async (key) => {
+        const schema = objectWithRestAsync({ key: string() }, number());
         const input = { key: 'foo', [key]: 'bar' };
         expect(await schema['~run']({ value: input }, {})).toStrictEqual({
           typed: false,
@@ -1037,41 +1059,5 @@ describe('objectWithRestAsync', () => {
         } satisfies FailureDataset<InferIssue<typeof schema>>);
       }
     );
-  });
-
-  describe('should parse declared keys colliding with the object prototype', () => {
-    test.each([
-      'toString',
-      'valueOf',
-      'hasOwnProperty',
-      'constructor',
-      'prototype',
-    ])('for declared %s key', async (key) => {
-      const schema = objectWithRestAsync({ [key]: string() }, number());
-      const input = { [key]: 'foo' };
-      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
-        typed: true,
-        value: input,
-      });
-    });
-  });
-
-  test('without including excluded unknown keys', async () => {
-    const schema = objectWithRestAsync({ key: string() }, number());
-    const input = JSON.parse(
-      '{"key":"foo","__proto__":{"admin":true},"constructor":"bar","prototype":"baz"}'
-    );
-    const dataset = await schema['~run']({ value: input }, {});
-    expect(dataset).toStrictEqual({ typed: true, value: { key: 'foo' } });
-    expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
-  });
-
-  test('for valid rest keys colliding with the object prototype', async () => {
-    const schema = objectWithRestAsync({ key: string() }, number());
-    const input = { key: 'foo', toString: 1, valueOf: 2, hasOwnProperty: 3 };
-    expect(await schema['~run']({ value: input }, {})).toStrictEqual({
-      typed: true,
-      value: input,
-    });
   });
 });

--- a/library/src/schemas/objectWithRest/objectWithRestAsync.ts
+++ b/library/src/schemas/objectWithRest/objectWithRestAsync.ts
@@ -179,7 +179,8 @@ export function objectWithRestAsync(
             Object.entries(input)
               .filter(
                 ([key]) =>
-                  _isValidObjectKey(input, key) && !(key in this.entries)
+                  _isValidObjectKey(input, key) &&
+                  !Object.prototype.hasOwnProperty.call(this.entries, key)
               )
               .map(
                 async ([key, value]) =>

--- a/library/src/schemas/objectWithRest/objectWithRestAsync.ts
+++ b/library/src/schemas/objectWithRest/objectWithRestAsync.ts
@@ -177,7 +177,8 @@ export function objectWithRestAsync(
             Object.entries(input)
               .filter(
                 ([key]) =>
-                  _isValidObjectKey(input, key) && !(key in this.entries)
+                  _isValidObjectKey(input, key) &&
+                  !Object.prototype.hasOwnProperty.call(this.entries, key)
               )
               .map(
                 async ([key, value]) =>

--- a/library/src/schemas/strictObject/strictObject.test.ts
+++ b/library/src/schemas/strictObject/strictObject.test.ts
@@ -696,4 +696,44 @@ describe('strictObject', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should reject keys colliding with the object prototype', () => {
+    const schema = strictObject({ key: string() });
+
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for unknown key named like an object prototype member', () => {
+      const input = { key: 'foo', toString: 'bar' };
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: { key: 'foo' },
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'strict_object',
+            input: 'toString',
+            expected: 'never',
+            received: '"toString"',
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key: 'toString',
+                value: input.toString,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+  });
 });

--- a/library/src/schemas/strictObject/strictObject.test.ts
+++ b/library/src/schemas/strictObject/strictObject.test.ts
@@ -696,4 +696,67 @@ describe('strictObject', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should reject keys colliding with the object prototype', () => {
+    const schema = strictObject({ key: string() });
+
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      '__proto__',
+    ])('for unknown %s key', (key) => {
+      const input = { key: 'foo', [key]: 'bar' };
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: { key: 'foo' },
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'strict_object',
+            input: key,
+            expected: 'never',
+            received: `"${key}"`,
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key,
+                value: input[key],
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+  });
+
+  describe('should parse declared keys colliding with the object prototype', () => {
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', (key) => {
+      const schema = strictObject({ [key]: string() });
+      const input = { [key]: 'foo' };
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: input,
+      });
+    });
+  });
 });

--- a/library/src/schemas/strictObject/strictObject.test.ts
+++ b/library/src/schemas/strictObject/strictObject.test.ts
@@ -67,6 +67,18 @@ describe('strictObject', () => {
         { key1: 'foo', key2: 123 },
       ]);
     });
+
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', (key) => {
+      const schema = strictObject({ [key]: string() });
+      const input = { [key]: 'foo' };
+      expectNoSchemaIssue(schema, [input]);
+    });
   });
 
   describe('should return dataset with issues', () => {
@@ -695,19 +707,6 @@ describe('strictObject', () => {
         ],
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
-  });
-
-  describe('should reject keys colliding with the object prototype', () => {
-    const schema = strictObject({ key: string() });
-
-    const baseInfo = {
-      message: expect.any(String),
-      requirement: undefined,
-      issues: undefined,
-      lang: undefined,
-      abortEarly: undefined,
-      abortPipeEarly: undefined,
-    };
 
     test.each([
       'toString',
@@ -716,6 +715,7 @@ describe('strictObject', () => {
       'constructor',
       '__proto__',
     ])('for unknown %s key', (key) => {
+      const schema = strictObject({ key: string() });
       const input = { key: 'foo', [key]: 'bar' };
       expect(schema['~run']({ value: input }, {})).toStrictEqual({
         typed: false,
@@ -740,23 +740,6 @@ describe('strictObject', () => {
           },
         ],
       } satisfies FailureDataset<InferIssue<typeof schema>>);
-    });
-  });
-
-  describe('should parse declared keys colliding with the object prototype', () => {
-    test.each([
-      'toString',
-      'valueOf',
-      'hasOwnProperty',
-      'constructor',
-      'prototype',
-    ])('for declared %s key', (key) => {
-      const schema = strictObject({ [key]: string() });
-      const input = { [key]: 'foo' };
-      expect(schema['~run']({ value: input }, {})).toStrictEqual({
-        typed: true,
-        value: input,
-      });
     });
   });
 });

--- a/library/src/schemas/strictObject/strictObject.ts
+++ b/library/src/schemas/strictObject/strictObject.ts
@@ -200,7 +200,7 @@ export function strictObject(
         // Check input for unknown keys if necessary
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (!(key in this.entries)) {
+            if (!Object.prototype.hasOwnProperty.call(this.entries, key)) {
               _addIssue(this, 'key', dataset, config, {
                 input: key,
                 expected: 'never',

--- a/library/src/schemas/strictObject/strictObject.ts
+++ b/library/src/schemas/strictObject/strictObject.ts
@@ -198,7 +198,7 @@ export function strictObject(
         // Check input for unknown keys if necessary
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (!(key in this.entries)) {
+            if (!Object.prototype.hasOwnProperty.call(this.entries, key)) {
               _addIssue(this, 'key', dataset, config, {
                 input: key,
                 expected: 'never',

--- a/library/src/schemas/strictObject/strictObjectAsync.test.ts
+++ b/library/src/schemas/strictObject/strictObjectAsync.test.ts
@@ -873,4 +873,44 @@ describe('strictObjectAsync', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should reject keys colliding with the object prototype', () => {
+    const schema = strictObjectAsync({ key: string() });
+
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for unknown key named like an object prototype member', async () => {
+      const input = { key: 'foo', toString: 'bar' };
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: { key: 'foo' },
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'strict_object',
+            input: 'toString',
+            expected: 'never',
+            received: '"toString"',
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key: 'toString',
+                value: input.toString,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+  });
 });

--- a/library/src/schemas/strictObject/strictObjectAsync.test.ts
+++ b/library/src/schemas/strictObject/strictObjectAsync.test.ts
@@ -873,4 +873,67 @@ describe('strictObjectAsync', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should reject keys colliding with the object prototype', () => {
+    const schema = strictObjectAsync({ key: string() });
+
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      '__proto__',
+    ])('for unknown %s key', async (key) => {
+      const input = { key: 'foo', [key]: 'bar' };
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: { key: 'foo' },
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'strict_object',
+            input: key,
+            expected: 'never',
+            received: `"${key}"`,
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key,
+                value: input[key],
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+  });
+
+  describe('should parse declared keys colliding with the object prototype', () => {
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', async (key) => {
+      const schema = strictObjectAsync({ [key]: string() });
+      const input = { [key]: 'foo' };
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: true,
+        value: input,
+      });
+    });
+  });
 });

--- a/library/src/schemas/strictObject/strictObjectAsync.test.ts
+++ b/library/src/schemas/strictObject/strictObjectAsync.test.ts
@@ -77,6 +77,18 @@ describe('strictObjectAsync', () => {
         [{ key1: 'foo', key2: 123 }]
       );
     });
+
+    test.each([
+      'toString',
+      'valueOf',
+      'hasOwnProperty',
+      'constructor',
+      'prototype',
+    ])('for declared %s key', async (key) => {
+      const schema = strictObjectAsync({ [key]: string() });
+      const input = { [key]: 'foo' };
+      await expectNoSchemaIssueAsync(schema, [input]);
+    });
   });
 
   describe('should return dataset with issues', () => {
@@ -872,19 +884,6 @@ describe('strictObjectAsync', () => {
         ],
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
-  });
-
-  describe('should reject keys colliding with the object prototype', () => {
-    const schema = strictObjectAsync({ key: string() });
-
-    const baseInfo = {
-      message: expect.any(String),
-      requirement: undefined,
-      issues: undefined,
-      lang: undefined,
-      abortEarly: undefined,
-      abortPipeEarly: undefined,
-    };
 
     test.each([
       'toString',
@@ -893,6 +892,7 @@ describe('strictObjectAsync', () => {
       'constructor',
       '__proto__',
     ])('for unknown %s key', async (key) => {
+      const schema = strictObjectAsync({ key: string() });
       const input = { key: 'foo', [key]: 'bar' };
       expect(await schema['~run']({ value: input }, {})).toStrictEqual({
         typed: false,
@@ -917,23 +917,6 @@ describe('strictObjectAsync', () => {
           },
         ],
       } satisfies FailureDataset<InferIssue<typeof schema>>);
-    });
-  });
-
-  describe('should parse declared keys colliding with the object prototype', () => {
-    test.each([
-      'toString',
-      'valueOf',
-      'hasOwnProperty',
-      'constructor',
-      'prototype',
-    ])('for declared %s key', async (key) => {
-      const schema = strictObjectAsync({ [key]: string() });
-      const input = { [key]: 'foo' };
-      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
-        typed: true,
-        value: input,
-      });
     });
   });
 });

--- a/library/src/schemas/strictObject/strictObjectAsync.ts
+++ b/library/src/schemas/strictObject/strictObjectAsync.ts
@@ -221,7 +221,7 @@ export function strictObjectAsync(
         // Check input for unknown keys if necessary
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (!(key in this.entries)) {
+            if (!Object.prototype.hasOwnProperty.call(this.entries, key)) {
               _addIssue(this, 'key', dataset, config, {
                 input: key,
                 expected: 'never',

--- a/library/src/schemas/strictObject/strictObjectAsync.ts
+++ b/library/src/schemas/strictObject/strictObjectAsync.ts
@@ -219,7 +219,7 @@ export function strictObjectAsync(
         // Check input for unknown keys if necessary
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (!(key in this.entries)) {
+            if (!Object.prototype.hasOwnProperty.call(this.entries, key)) {
               _addIssue(this, 'key', dataset, config, {
                 input: key,
                 expected: 'never',


### PR DESCRIPTION
## Summary

`strictObject`, `looseObject`, `objectWithRest` and their async variants check whether an input key is a defined schema entry with `key in this.entries`. The `in` operator also matches inherited `Object.prototype` members, so an input key named like a prototype member is treated as a defined entry.

This is the same class of bug as the `flatten` and `intersect` fixes in #1522, here in the entry-membership check.

## Effect

For an input key that collides with a prototype member (`toString`, `valueOf`, `constructor`, `__proto__`, ...):

- `strictObject` / `strictObjectAsync` fail to reject it as an unknown key, even though it is not a defined entry. A `__proto__` or `constructor` key passes a strict schema silently.
- `looseObject` / `looseObjectAsync` drop it instead of passing it through.
- `objectWithRest` / `objectWithRestAsync` skip it instead of validating it against the `rest` schema.

Before the fix:

```ts
v.parse(v.strictObject({ name: v.string() }), { name: 'a', toString: 'b' });
// returns { name: 'a' }; the unknown `toString` key is not reported
```

## Fix

Replace `key in this.entries` with `Object.prototype.hasOwnProperty.call(this.entries, key)`, the same own-property check already used by `_isValidObjectKey` for input keys and by the #1522 fixes. A schema that intentionally defines an entry named like a prototype member (`v.object({ toString: v.string() })`) still works, since `hasOwnProperty` reports developer-defined own entries.

## Tests

Added a test to each affected schema: the prototype-named key is rejected for strict, passed through for loose, and validated against `rest` for object-with-rest. Lint, Prettier and the affected Vitest suites pass for the changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected object schema handling for keys that overlap with built-in object properties.
  - Declared keys such as `toString`, `valueOf`, `hasOwnProperty`, `constructor`, and `prototype` are now validated correctly.
  - Unknown keys are classified consistently, while unsafe keys such as `__proto__` remain excluded from parsed output.
  - Applied the fix across strict, loose, rest-aware, and asynchronous object schemas.

- **Tests**
  - Added coverage for prototype-colliding keys and unsafe key handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->