### PR TITLE
fix(codemod): handle zod/v4-mini imports in zod-to-valibot transform

### DIFF
--- a/codemod/zod-to-valibot/__testfixtures__/multiple-imports-from-zod/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/multiple-imports-from-zod/output.ts
@@ -1,4 +1,4 @@
-/* @valibot-migrate: unable to transform imports from Zod to Valibot: Expected exactly one import specifier from "zod" or "zod/v4". */
+/* @valibot-migrate: unable to transform imports from Zod to Valibot: Expected exactly one import specifier from "zod", "zod/v4", or "zod/v4-mini". */
 import { z, ZodAnyType } from "zod";
 
 const Schema1 = z.string();

--- a/codemod/zod-to-valibot/__testfixtures__/v4-mini-import/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/v4-mini-import/input.ts
@@ -1,0 +1,3 @@
+import * as z from "zod/v4-mini";
+
+const StringSchema = z.string();

--- a/codemod/zod-to-valibot/__testfixtures__/v4-mini-import/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/v4-mini-import/output.ts
@@ -1,0 +1,3 @@
+import * as v from "valibot";
+
+const StringSchema = v.string();

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -71,6 +71,7 @@ defineTests(transform, [
   'undefined-schema',
   'union-schema',
   'unknown-schema',
+  'v4-mini-import',
   'validation-error-msg',
   'void-schema',
   'zod-enum',

--- a/codemod/zod-to-valibot/src/transform/imports/imports.ts
+++ b/codemod/zod-to-valibot/src/transform/imports/imports.ts
@@ -14,14 +14,17 @@ export function transformImports(
   // Find all Zod import statements
   const zodImports = root.find(
     j.ImportDeclaration,
-    (name) => name.source.value === 'zod' || name.source.value === 'zod/v4'
+    (name) =>
+      name.source.value === 'zod' ||
+      name.source.value === 'zod/v4' ||
+      name.source.value === 'zod/v4-mini'
   );
   // Check the number of statements is exactly one
   const importNodes = zodImports.nodes();
   if (importNodes.length !== 1) {
     return {
       conclusion: importNodes.length === 0 ? 'skip' : 'unsuccessful',
-      cause: 'Expected exactly one import statement from "zod" or "zod/v4".',
+      cause: 'Expected exactly one import statement from "zod", "zod/v4", or "zod/v4-mini".',
     };
   }
   // Check the number of specifiers is exactly one
@@ -29,7 +32,7 @@ export function transformImports(
   if (importSpecifiers?.length !== 1) {
     return {
       conclusion: 'unsuccessful',
-      cause: 'Expected exactly one import specifier from "zod" or "zod/v4".',
+      cause: 'Expected exactly one import specifier from "zod", "zod/v4", or "zod/v4-mini".',
     };
   }
   // Obtain the identifier


### PR DESCRIPTION
The codemod's import source check handles `zod` and `zod/v4` but silently skips files that import from `zod/v4-mini`. This adds `zod/v4-mini` to the condition so those files are correctly transformed.

Closes #1500

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an additional Zod import style, including `zod/v4-mini`, in the migration flow.
* **Bug Fixes**
  * Improved migration error messages so unsupported import issues now report the full set of accepted Zod import sources.
  * Expanded migration coverage for the new import variant to keep conversions consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->