### PR TITLE
fix(codemod): handle static z.extend(Schema, {...}) form

### DIFF
--- a/codemod/zod-to-valibot/__testfixtures__/object-extend-static/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-extend-static/input.ts
@@ -1,0 +1,15 @@
+import { z } from "zod";
+
+const Foo = z.object({
+  foo: z.string(),
+});
+
+// static z.extend(Schema, { ... }) — schema reference as base
+const Bar = z.extend(Foo, {
+  bar: z.number(),
+});
+
+// static z.extend with inline object as base
+const Baz = z.extend(z.object({ foo: z.string() }), {
+  bar: z.number(),
+});

--- a/codemod/zod-to-valibot/__testfixtures__/object-extend-static/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-extend-static/output.ts
@@ -1,0 +1,19 @@
+import * as v from "valibot";
+
+const Foo = v.object({
+  foo: v.string(),
+});
+
+// static z.extend(Schema, { ... }) — schema reference as base
+const Bar = v.object({
+  .../*@valibot-migrate we can't detect if Foo has a `pipe` operator, if it does you might need to migrate this by hand otherwise it will loose it's pipeline*/
+  Foo.entries,
+
+  bar: v.number()
+});
+
+// static z.extend with inline object as base
+const Baz = v.object({
+  foo: v.string(),
+  bar: v.number()
+});

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -41,6 +41,7 @@ defineTests(transform, [
   'object-catchall',
   'object-deepPartial',
   'object-extend',
+  'object-extend-static',
   'object-keyof',
   'object-merge',
   'object-omit',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
@@ -582,11 +582,35 @@ function transformSchemasAndLinksHelper(
           objectModifier
         );
       } else if (isZodMethodName(propertyName)) {
+        // Static namespace form: z.extend(BaseSchema, { ... })
+        // After import rewrite this becomes v.extend(BaseSchema, { ... }).
+        // In this form transformedExp is null (no schema has been built yet)
+        // and there are exactly 2 arguments: the base schema and the extension
+        // object. Swap schemaExp to args[0] and pass only args[1] onward so
+        // that transformExtend receives the same shape as the method form.
+        let schemaExpForMethod: j.CallExpression | j.MemberExpression | j.Identifier =
+          transformedExp ?? j.identifier(identifier);
+        let argsForMethod = cur.value.arguments;
+        if (
+          propertyName === 'extend' &&
+          transformedExp === null &&
+          cur.value.arguments.length === 2
+        ) {
+          const baseArg = cur.value.arguments[0];
+          if (
+            baseArg.type === 'Identifier' ||
+            baseArg.type === 'CallExpression' ||
+            baseArg.type === 'MemberExpression'
+          ) {
+            schemaExpForMethod = baseArg;
+            argsForMethod = [cur.value.arguments[1]];
+          }
+        }
         transformedExp = toValibotMethodExp(
           valibotIdentifier,
           propertyName,
-          transformedExp ?? j.identifier(identifier),
-          cur.value.arguments
+          schemaExpForMethod,
+          argsForMethod
         );
       } else if (isZodValidatorName(propertyName)) {
         if (curSchemaType === null) {


### PR DESCRIPTION
The zod-to-valibot codemod only handled the method form `Foo.extend({...})` but not the static namespace form `z.extend(Foo, {...})`.

When the transformer encountered `z.extend(Foo, { bar: z.string() })` it treated the namespace identifier itself as the base schema and the first argument as the extension, producing garbled output instead of `v.object({ ...Foo.entries, bar: v.string() })`.

**Root cause:** The import rewrite transforms `z.extend(Foo, {...})` into `v.extend(Foo, {...})`. The chain walker then hits `v.extend` as a method call with `transformedExp === null`, so it falls through to `toValibotMethodExp` with `schemaExp = j.identifier('v')` (the namespace) and `args = [Foo, {...}]` — both wrong.

**Fix:** In the `isZodMethodName` branch of the chain walker, detect when `propertyName === 'extend'`, `transformedExp === null` (nothing built yet, so we are on the namespace), and exactly 2 arguments are present. In that case extract `args[0]` as the base schema expression and `args[1]` as the extension, matching the shape expected by `transformExtend`.

Adds a test fixture (`object-extend-static`) covering both a schema-reference base and an inline-object base.

Closes #1502

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved conversion support for static schema extension patterns, including cases that reuse an existing schema or start from an inline object.
* **Bug Fixes**
  * Fixed handling of static `extend` conversions so the generated output now uses the correct base schema and extension values.
* **Tests**
  * Added new test coverage for these extension scenarios to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->