### PR TITLE
Add EviKit framework to ecosystem

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -29,6 +29,7 @@ contributors:
   - victorgarciaesgi
   - gadicc
   - haihv
+  - nykula
 ---
 
 # Ecosystem
@@ -39,6 +40,7 @@ This page is for you if you are looking for frameworks or libraries that support
 
 ## Frameworks
 
+- [EviKit](https://codeberg.org/nykula/evikit): Preact SSR framework using Valibot to let you define node:sqlite ORM schemas and validate OpenAPI (Swagger) inputs and outputs
 - [NestJS](https://docs.nestjs.com): A progressive Node.js framework for building efficient, reliable and scalable server-side applications
 - [Qwik](https://qwik.dev): A web framework which helps you build instantly-interactive web apps at any scale without effort.
 


### PR DESCRIPTION
Hi, I made a Preact SSR framework that uses Valibot as a key component. I appreciate if you can add it to the Valibot ecosystem page.

As the [Fediverse announcement](https://programming.dev/post/52844785) says:

> Input/output validation using Valibot is first-class. Type checking catches if e.g. after an upgrade your API starts returning something different from your declaration. With less need for boilerplate unit tests, you can focus on end-to-end replication of real user scenarios.

> Most apps need databases. Why not try the node:sqlite built-in? I made it easy to declare a schema using the same Valibot helpers that I use for API declaration. EviKit keeps the database in a standard location following the XDG specification. You can save file uploads as SQLite blobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Ecosystem guide by adding **EviKit** to the **Frameworks** section.
  * Added **nykula** to the guide’s **contributors** list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->