### PR TITLE
fix: correct typos in JSDoc and inline comments

### DIFF
--- a/library/src/methods/forward/forward.ts
+++ b/library/src/methods/forward/forward.ts
@@ -9,7 +9,7 @@ import type { RequiredPath, ValidPath } from './types.ts';
 // breaking the type inference, as the current implementation loses some type
 // information by returning a `BaseValidation` instead of the original type.
 // In the process, we should also figure out how to add a `.forward' property
-// to the returnd object in a type-safe way, similar to how the `fallback`
+// to the returned object in a type-safe way, similar to how the `fallback`
 // method works.
 
 /**

--- a/library/src/methods/forward/forwardAsync.ts
+++ b/library/src/methods/forward/forwardAsync.ts
@@ -10,7 +10,7 @@ import type { RequiredPath, ValidPath } from './types.ts';
 // breaking the type inference, as the current implementation loses some type
 // information by returning a `BaseValidation` instead of the original type.
 // In the process, we should also figure out how to add a `.forward' property
-// to the returnd object in a type-safe way, similar to how the `fallback`
+// to the returned object in a type-safe way, similar to how the `fallback`
 // method works.
 
 /**

--- a/library/src/methods/safeParse/types.ts
+++ b/library/src/methods/safeParse/types.ts
@@ -16,7 +16,7 @@ export type SafeParseResult<
 > =
   | {
       /**
-       * Whether is's typed.
+       * Whether it's typed.
        */
       readonly typed: true;
       /**

--- a/library/src/types/dataset.ts
+++ b/library/src/types/dataset.ts
@@ -5,7 +5,7 @@ import type { BaseIssue } from './issue.ts';
  */
 export interface UnknownDataset {
   /**
-   * Whether is's typed.
+   * Whether it's typed.
    */
   typed?: false;
   /**
@@ -23,7 +23,7 @@ export interface UnknownDataset {
  */
 export interface SuccessDataset<TValue> {
   /**
-   * Whether is's typed.
+   * Whether it's typed.
    */
   typed: true;
   /**
@@ -41,7 +41,7 @@ export interface SuccessDataset<TValue> {
  */
 export interface PartialDataset<TValue, TIssue extends BaseIssue<unknown>> {
   /**
-   * Whether is's typed.
+   * Whether it's typed.
    */
   typed: true;
   /**
@@ -59,7 +59,7 @@ export interface PartialDataset<TValue, TIssue extends BaseIssue<unknown>> {
  */
 export interface FailureDataset<TIssue extends BaseIssue<unknown>> {
   /**
-   * Whether is's typed.
+   * Whether it's typed.
    */
   typed: false;
   /**


### PR DESCRIPTION
## Summary

Fixes several small typos in JSDoc comments and inline code comments:

- `is's` -> `it's` in 4 dataset interface JSDoc comments (`UnknownDataset`, `SuccessDataset`, `PartialDataset`, `FailureDataset`) in `library/src/types/dataset.ts`
- `is's` -> `it's` in `SafeParseResult` JSDoc in `library/src/methods/safeParse/types.ts`
- `returnd` -> `returned` in TODO comment in `library/src/methods/forward/forward.ts`
- `returnd` -> `returned` in TODO comment in `library/src/methods/forward/forwardAsync.ts`

No logic changes — comments and JSDoc only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected several wording and spelling issues in inline documentation.
  * Improved clarity in descriptions related to forwarded values, async forwarding, safe parse results, and dataset types.
  * No functional, type, or API behavior changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->