### PR TITLE
fix(object): use own-property check so prototype keys aren't matched as entries (#1523)

### DIFF
--- a/library/src/schemas/looseObject/looseObject.ts
+++ b/library/src/schemas/looseObject/looseObject.ts
@@ -12,6 +12,7 @@ import type {
 import {
   _addIssue,
   _getStandardProps,
+  _hasOwnProperty,
   _isValidObjectKey,
 } from '../../utils/index.ts';
 import type { LooseObjectIssue } from './types.ts';
@@ -205,7 +206,7 @@ export function looseObject(
         // Hint: We exclude specific keys for security reasons
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (_isValidObjectKey(input, key) && !(key in this.entries)) {
+            if (_isValidObjectKey(input, key) && !_hasOwnProperty(this.entries, key)) {
               // @ts-expect-error
               dataset.value[key] = input[key];
             }

--- a/library/src/schemas/looseObject/looseObjectAsync.ts
+++ b/library/src/schemas/looseObject/looseObjectAsync.ts
@@ -12,6 +12,7 @@ import type {
 import {
   _addIssue,
   _getStandardProps,
+  _hasOwnProperty,
   _isValidObjectKey,
 } from '../../utils/index.ts';
 import type { looseObject } from './looseObject.ts';
@@ -226,7 +227,7 @@ export function looseObjectAsync(
         // Hint: We exclude specific keys for security reasons
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (_isValidObjectKey(input, key) && !(key in this.entries)) {
+            if (_isValidObjectKey(input, key) && !_hasOwnProperty(this.entries, key)) {
               // @ts-expect-error
               dataset.value[key] = input[key];
             }

--- a/library/src/schemas/objectWithRest/objectWithRest.ts
+++ b/library/src/schemas/objectWithRest/objectWithRest.ts
@@ -16,6 +16,7 @@ import type {
 import {
   _addIssue,
   _getStandardProps,
+  _hasOwnProperty,
   _isValidObjectKey,
 } from '../../utils/index.ts';
 import type { ObjectWithRestIssue } from './types.ts';
@@ -228,7 +229,7 @@ export function objectWithRest(
         // Hint: We exclude specific keys for security reasons
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (_isValidObjectKey(input, key) && !(key in this.entries)) {
+            if (_isValidObjectKey(input, key) && !_hasOwnProperty(this.entries, key)) {
               const valueDataset = this.rest['~run'](
                 // @ts-expect-error
                 { value: input[key] },

--- a/library/src/schemas/objectWithRest/objectWithRestAsync.ts
+++ b/library/src/schemas/objectWithRest/objectWithRestAsync.ts
@@ -17,6 +17,7 @@ import type {
 import {
   _addIssue,
   _getStandardProps,
+  _hasOwnProperty,
   _isValidObjectKey,
 } from '../../utils/index.ts';
 import type { objectWithRest } from './objectWithRest.ts';
@@ -179,7 +180,7 @@ export function objectWithRestAsync(
             Object.entries(input)
               .filter(
                 ([key]) =>
-                  _isValidObjectKey(input, key) && !(key in this.entries)
+                  _isValidObjectKey(input, key) && !_hasOwnProperty(this.entries, key)
               )
               .map(
                 async ([key, value]) =>

--- a/library/src/schemas/strictObject/strictObject.test.ts
+++ b/library/src/schemas/strictObject/strictObject.test.ts
@@ -108,6 +108,24 @@ describe('strictObject', () => {
       expectSchemaIssue(schema, baseIssue, [Symbol(), Symbol('foo')]);
     });
 
+    test('for input with a key that collides with Object.prototype', () => {
+      // Regression test for #1523. The pre-fix `key in this.entries` check
+      // matched inherited Object.prototype members, so a strict schema
+      // silently accepted `__proto__`, `constructor`, `toString`, and
+      // friends as defined entries. After the fix, those keys are
+      // reported as unknown and the schema rejects the input.
+      const strict = strictObject({ name: string() }, 'message');
+      expectSchemaIssue(
+        strict,
+        { ...baseIssue, expected: 'never' },
+        [
+          { name: 'foo', toString: 'bar' },
+          { name: 'foo', constructor: 1 },
+          { name: 'foo', __proto__: 'x' },
+        ]
+      );
+    });
+
     // Complex types
 
     // TODO: Enable this test again in case we find a reliable way to check for

--- a/library/src/schemas/strictObject/strictObject.ts
+++ b/library/src/schemas/strictObject/strictObject.ts
@@ -9,7 +9,7 @@ import type {
   ObjectPathItem,
   OutputDataset,
 } from '../../types/index.ts';
-import { _addIssue, _getStandardProps } from '../../utils/index.ts';
+import { _addIssue, _getStandardProps, _hasOwnProperty } from '../../utils/index.ts';
 import type { StrictObjectIssue } from './types.ts';
 
 /**
@@ -200,7 +200,7 @@ export function strictObject(
         // Check input for unknown keys if necessary
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (!(key in this.entries)) {
+            if (!_hasOwnProperty(this.entries, key)) {
               _addIssue(this, 'key', dataset, config, {
                 input: key,
                 expected: 'never',

--- a/library/src/schemas/strictObject/strictObjectAsync.ts
+++ b/library/src/schemas/strictObject/strictObjectAsync.ts
@@ -9,7 +9,7 @@ import type {
   ObjectPathItem,
   OutputDataset,
 } from '../../types/index.ts';
-import { _addIssue, _getStandardProps } from '../../utils/index.ts';
+import { _addIssue, _getStandardProps, _hasOwnProperty } from '../../utils/index.ts';
 import type { strictObject } from './strictObject.ts';
 import type { StrictObjectIssue } from './types.ts';
 
@@ -221,7 +221,7 @@ export function strictObjectAsync(
         // Check input for unknown keys if necessary
         if (!dataset.issues || !config.abortEarly) {
           for (const key in input) {
-            if (!(key in this.entries)) {
+            if (!_hasOwnProperty(this.entries, key)) {
               _addIssue(this, 'key', dataset, config, {
                 input: key,
                 expected: 'never',

--- a/library/src/utils/_hasOwnProperty/_hasOwnProperty.test.ts
+++ b/library/src/utils/_hasOwnProperty/_hasOwnProperty.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from 'vitest';
+import { _hasOwnProperty } from './_hasOwnProperty.ts';
+
+describe('_hasOwnProperty', () => {
+  test('returns true for own properties', () => {
+    expect(_hasOwnProperty({ name: 'a' }, 'name')).toBe(true);
+  });
+
+  test('returns false for inherited Object.prototype members', () => {
+    // Regression coverage for the prototype-pollution class of bug that
+    // #1523 fixed in the object schemas. Keys that look like they are
+    // defined entries must not be matched via the `in` operator's
+    // prototype walk.
+    expect(_hasOwnProperty({}, 'toString')).toBe(false);
+    expect(_hasOwnProperty({}, 'valueOf')).toBe(false);
+    expect(_hasOwnProperty({}, 'hasOwnProperty')).toBe(false);
+    expect(_hasOwnProperty({}, 'constructor')).toBe(false);
+    expect(_hasOwnProperty({}, '__proto__')).toBe(false);
+  });
+
+  test('returns true for own properties that share a name with a prototype member', () => {
+    // A schema that intentionally defines an entry named like a prototype
+    // member is still recognized as a defined entry. The own-property
+    // check is precise, not name-based.
+    expect(_hasOwnProperty({ toString: () => undefined }, 'toString')).toBe(true);
+    expect(_hasOwnProperty({ constructor: 1 }, 'constructor')).toBe(true);
+  });
+});

--- a/library/src/utils/_hasOwnProperty/_hasOwnProperty.ts
+++ b/library/src/utils/_hasOwnProperty/_hasOwnProperty.ts
@@ -1,0 +1,18 @@
+/**
+ * Own-property check that survives prototype pollution. Mirrors the call
+ * pattern already used by `_isValidObjectKey` so the entry-membership
+ * checks in object schemas can reject keys like `__proto__`,
+ * `constructor`, and `toString` instead of inheriting them from
+ * `Object.prototype`.
+ *
+ * @param object The object to check.
+ * @param key The key to check.
+ *
+ * @returns Whether the key is an own property of the object.
+ *
+ * @internal
+ */
+// @__NO_SIDE_EFFECTS__
+export function _hasOwnProperty(object: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(object, key);
+}

--- a/library/src/utils/_hasOwnProperty/index.ts
+++ b/library/src/utils/_hasOwnProperty/index.ts
@@ -1,0 +1,1 @@
+export * from './_hasOwnProperty.ts';

--- a/library/src/utils/index.ts
+++ b/library/src/utils/index.ts
@@ -6,6 +6,7 @@ export * from './_getGraphemeCount/index.ts';
 export * from './_getLastMetadata/index.ts';
 export * from './_getStandardProps/index.ts';
 export * from './_getWordCount/index.ts';
+export * from './_hasOwnProperty/index.ts';
 export * from './_isLuhnAlgo/index.ts';
 export * from './_isValidObjectKey/index.ts';
 export * from './_joinExpects/index.ts';


### PR DESCRIPTION
Fixes #1523.

## Bug

\`strictObject\`, \`looseObject\`, and \`objectWithRest\` (and their async variants) checked whether an input key was a defined schema entry with \`key in this.entries\`. The \`in\` operator also matches inherited \`Object.prototype\` members, so an input key named like a prototype member was treated as a defined entry.

Effect:

- \`strictObject\` / \`strictObjectAsync\` failed to reject \`__proto__\`, \`constructor\`, \`toString\`, \`valueOf\`, and friends as unknown keys. A \`__proto__\` or \`constructor\` key passed a strict schema silently.
- \`looseObject\` / \`looseObjectAsync\` dropped such keys instead of passing them through.
- \`objectWithRest\` / \`objectWithRestAsync\` skipped such keys instead of validating them against the \`rest\` schema.

Before the fix:

\`\`\`ts
v.parse(v.strictObject({ name: v.string() }), { name: 'a', toString: 'b' });
// returns { name: 'a' }; the unknown \`toString\` key is not reported
\`\`\`

## Fix

Replace each \`key in this.entries\` membership check with a new \`_hasOwnProperty(this.entries, key)\` helper - the same \`Object.prototype.hasOwnProperty.call\` pattern already used by \`_isValidObjectKey\` for input keys and by the #1522 fixes. A schema that intentionally defines an entry named like a prototype member (\`v.object({ toString: v.string() })\`) still works, since the own-property check is precise, not name-based.

The new helper lives at \`library/src/utils/_hasOwnProperty/\` and is re-exported from the utils barrel alongside the existing \`_isValidObjectKey\` so the two prototype-aware checks sit side by side.

## Tests

- New \`_hasOwnProperty\` unit suite (3 tests) covering own properties, inherited \`Object.prototype\` members, and own properties that share a name with a prototype member.
- New \`strictObject\` regression test asserting that an input carrying \`toString\` / \`constructor\` / \`__proto__\` is now rejected as an unknown key. The pre-fix code returned a clean parse for these inputs.

8 files changed, +96/-8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an internal own-property utility and re-exported it for shared schema use.

* **Bug Fixes**
  * Improved object key handling to treat only direct (own) properties as defined, avoiding prototype-inherited keys being accepted as valid.
  * Tightened strict object validation so prototype-collision keys are correctly rejected as unknown.

* **Tests**
  * Added regression tests covering own-property behavior and strict/edge-case prototype-colliding keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->