### PR TITLE
docs(guides): fix dead Grit migration link in v0.31.0 migration guide

### DIFF
--- a/website/src/routes/guides/(migration)/migrate-to-v0.31.0/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-to-v0.31.0/index.mdx
@@ -17,7 +17,7 @@ Migrating Valibot from an older version to v0.31.0 isn't complicated. Except for
 
 ## Automatic upgrade
 
-We worked together with [Codemod](https://codemod.com/registry/valibot-migrate-to-v0-31-0) and [Grit](https://docs.grit.io/registry/github.com/open-circle/valibot/migrate_to_v0_31_0) to automatically upgrade your schemas to the new version with a single CLI command. Both codemods are similar. You can use one or the other. Simply run the command in the directory of your project.
+We worked together with [Codemod](https://codemod.com/registry/valibot-migrate-to-v0-31-0) and [Grit](https://docs.grit.io/) to automatically upgrade your schemas to the new version with a single CLI command. Both codemods are similar. You can use one or the other. Simply run the command in the directory of your project.
 
 > We recommend using a version control system like [Git](https://git-scm.com/) so that you can revert changes if the codemod screws something up.
 


### PR DESCRIPTION
The v0.31.0 migration guide points readers at the Grit registry page for the Valibot migration pattern, but that URL 404s:

```
$ curl -sIL -A 'Mozilla/5.0' https://docs.grit.io/registry/github.com/open-circle/valibot/migrate_to_v0_31_0
HTTP/2 404
```

The Grit registry moved/restructured since the migration was added, and the per-pattern docs page is no longer reachable. The Grit CLI command itself (`npx @getgrit/cli apply github.com/open-circle/valibot#migrate_to_v0_31_0`) still works, and the new [docs.grit.io root](https://docs.grit.io/) is a sensible landing page for the Grit tool itself.

Replaced the broken per-pattern link with the canonical docs root, keeping both Codemod and Grit mentioned side by side as the guide does today. Verified the new URL returns HTTP 200:

```
$ curl -sIL -A 'Mozilla/5.0' https://docs.grit.io/
HTTP/2 200
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the v0.31.0 migration guide’s automatic upgrade instructions with the current Codemod registry link and a link to the general Grit documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->