### PR TITLE
fix(website): replace dead oscollective.org link with opencollective.com/opensourcecollective

### DIFF
--- a/website/src/routes/blog/(posts)/introducing-open-circle/index.mdx
+++ b/website/src/routes/blog/(posts)/introducing-open-circle/index.mdx
@@ -36,7 +36,7 @@ Fabian Hiller forwards 100% of his GitHub sponsorings to Open Collective, and go
 
 #### Fiscal host
 
-[Open Source Collective](https://oscollective.org/) is now our fiscal host. This means that all sponsorings go into a non-profit organization, providing legal and financial infrastructure that helps us operate transparently and sustainably.
+[Open Source Collective](https://opencollective.com/opensourcecollective) is now our fiscal host. This means that all sponsorings go into a non-profit organization, providing legal and financial infrastructure that helps us operate transparently and sustainably.
 
 ### Unified ecosystem
 


### PR DESCRIPTION
## Summary

The Open Source Collective website (`https://oscollective.org/`) is returning HTTP 526 (Cloudflare origin unreachable) on every request — verified with 3 attempts on 2026-07-13 morning IST. The blog post "Introducing Open Circle" links to it as the fiscal host for Valibot.

This PR replaces the dead link with the canonical Open Source Collective entity page on Open Collective, which is the same organization (OSC is a 501(c)(6) nonprofit fiscal host).

## Change

`website/src/routes/blog/(posts)/introducing-open-circle/index.mdx:39`

```diff
-[Open Source Collective](https://oscollective.org/) is now our fiscal host.
+[Open Source Collective](https://opencollective.com/opensourcecollective) is now our fiscal host.
```

1 file, +1/-1. No library code touched (website-only), so no changeset is needed.

## Verification

- `https://oscollective.org/` → HTTP 526 (3 attempts, all 526)
- `https://opencollective.com/opensourcecollective` → HTTP 200, content: "Open Source Collective (OSC) is a 501(c)(6) nonprofit fiscal host that has been providing financial and legal infrastructure to open source projects since 2017"

The replacement page is the canonical fiscal-host entity on Open Collective, matching the context of the sentence (OSC is the project's fiscal host).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Fiscal Host link in the “Introducing Open Circle” blog post to point to the correct destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->