### PR TITLE
Add ArkEnv to ecosystem page

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -30,6 +30,7 @@ contributors:
   - gadicc
   - haihv
   - nykula
+  - yamcodes
 ---
 
 # Ecosystem
@@ -108,6 +109,7 @@ This page is for you if you are looking for frameworks or libraries that support
 - [@nest-lab/typeschema](https://github.com/jmcdo29/nest-lab/tree/main/packages/typeschema): A ValidationPipe that handles many schema validators in a class-based fashion for NestJS's input validation
 - [@traversable/valibot-test](https://github.com/traversable/schema/tree/main/packages/valibot-test): Random Valibot schema generator built for fuzz testing, includes generators for both valid and invalid data
 - [@valibot/i18n](https://github.com/open-circle/valibot/tree/main/packages/i18n): The official i18n translations for Valibot
+- [ArkEnv](https://github.com/yamcodes/arkenv): Typesafe environment variables validated with Valibot, for Node.js, Vite, Bun, Next.js, and Nuxt
 - [fastify-type-provider-valibot](https://github.com/qlaffont/fastify-type-provider-valibot): Fastify Type Provider with Valibot
 - [valibot-env](https://y-hiraoka.github.io/valibot-env): Environment variables validator with Valibot
 - [valibotx](https://github.com/IlyaSemenov/valibotx): A collection of extensions and shortcuts to core Valibot functions

--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -109,7 +109,7 @@ This page is for you if you are looking for frameworks or libraries that support
 - [@nest-lab/typeschema](https://github.com/jmcdo29/nest-lab/tree/main/packages/typeschema): A ValidationPipe that handles many schema validators in a class-based fashion for NestJS's input validation
 - [@traversable/valibot-test](https://github.com/traversable/schema/tree/main/packages/valibot-test): Random Valibot schema generator built for fuzz testing, includes generators for both valid and invalid data
 - [@valibot/i18n](https://github.com/open-circle/valibot/tree/main/packages/i18n): The official i18n translations for Valibot
-- [ArkEnv](https://github.com/yamcodes/arkenv): Environment variable validation from editor to runtime
+- [ArkEnv](https://github.com/yamcodes/arkenv): Environment variable validation from editor to runtime, for Next.js, Nuxt, Node.js, Vite, Bun, and more
 - [fastify-type-provider-valibot](https://github.com/qlaffont/fastify-type-provider-valibot): Fastify Type Provider with Valibot
 - [valibot-env](https://y-hiraoka.github.io/valibot-env): Environment variables validator with Valibot
 - [valibotx](https://github.com/IlyaSemenov/valibotx): A collection of extensions and shortcuts to core Valibot functions

--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -109,7 +109,7 @@ This page is for you if you are looking for frameworks or libraries that support
 - [@nest-lab/typeschema](https://github.com/jmcdo29/nest-lab/tree/main/packages/typeschema): A ValidationPipe that handles many schema validators in a class-based fashion for NestJS's input validation
 - [@traversable/valibot-test](https://github.com/traversable/schema/tree/main/packages/valibot-test): Random Valibot schema generator built for fuzz testing, includes generators for both valid and invalid data
 - [@valibot/i18n](https://github.com/open-circle/valibot/tree/main/packages/i18n): The official i18n translations for Valibot
-- [ArkEnv](https://github.com/yamcodes/arkenv): Typesafe environment variables validated with Valibot, for Node.js, Vite, Bun, Next.js, and Nuxt
+- [ArkEnv](https://github.com/yamcodes/arkenv): Environment variable validation from editor to runtime
 - [fastify-type-provider-valibot](https://github.com/qlaffont/fastify-type-provider-valibot): Fastify Type Provider with Valibot
 - [valibot-env](https://y-hiraoka.github.io/valibot-env): Environment variables validator with Valibot
 - [valibotx](https://github.com/IlyaSemenov/valibotx): A collection of extensions and shortcuts to core Valibot functions


### PR DESCRIPTION
This PR adds [ArkEnv](https://github.com/yamcodes/arkenv) to the "Utilities" category of the ecosystem page, in alphabetical order as requested on the page.

ArkEnv provides typesafe environment variable parsing and validation with Valibot (or any other Standard Schema library), with first-class integrations for Node.js, Vite, Bun, Next.js, and Nuxt.

I also added myself to the `contributors` list in the frontmatter, following the existing convention. Happy to adjust the wording or category if you prefer!

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added ArkEnv to the Valibot ecosystem guide under Utilities.
  * Added a new contributor to the guide’s acknowledgments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->