### PR TITLE
Add more migration guides to website

### DIFF
--- a/website/src/routes/guides/(migration)/migrate-from-class-validator/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-class-validator/index.mdx
@@ -1,0 +1,204 @@
+---
+title: Migrate from class-validator
+description: >-
+  Migrating from class-validator to Valibot means switching from decorated
+  classes to schemas, which removes a lot of boilerplate.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from class-validator
+
+Migrating from [class-validator](https://github.com/typestack/class-validator) to Valibot is a bigger paradigm shift than for other libraries, since you are switching from decorated classes to schemas. In return, it removes a lot of boilerplate. You no longer need experimental decorators, `reflect-metadata` or class-transformer, and your schemas validate plain data directly, with the TypeScript type inferred automatically. The following guide will help you migrate step by step.
+
+## Replace classes with schemas
+
+Each decorated class becomes a schema, and each decorator becomes a schema function or an action within a <Link href="../pipelines/">pipeline</Link>. Since the class no longer exists, you infer the TypeScript type from the schema with <Link href="/api/InferOutput/">`InferOutput`</Link>.
+
+```ts
+// Change this
+import { IsEmail, IsInt, IsString, Min } from 'class-validator';
+
+class User {
+  @IsString()
+  name: string;
+
+  @IsEmail()
+  email: string;
+
+  @IsInt()
+  @Min(0)
+  age: number;
+}
+
+// To this
+import * as v from 'valibot';
+
+const UserSchema = v.object({
+  name: v.string(),
+  email: v.pipe(v.string(), v.email()),
+  age: v.pipe(v.number(), v.integer(), v.minValue(0)),
+});
+
+type User = v.InferOutput<typeof UserSchema>;
+```
+
+## Restructure code
+
+With class-validator, you first convert plain data to a class instance, for example with class-transformer's `plainToInstance`, and then validate it. With Valibot, you validate plain data directly. The `validate` method, which resolves to an array of validation errors, is replaced by <Link href="/api/safeParse/">`safeParse`</Link>, which returns a result object. Since Valibot is synchronous by default, there is no need for a separate `validateSync` method.
+
+```ts
+// Change this
+const user = plainToInstance(User, input);
+const errors = await validate(user);
+if (errors.length === 0) {
+  console.log(user);
+} else {
+  console.log(errors);
+}
+
+// To this
+const result = v.safeParse(UserSchema, input);
+if (result.success) {
+  console.log(result.output);
+} else {
+  console.log(result.issues);
+}
+```
+
+If you prefer an exception to be thrown on invalid input, as with `validateOrReject`, use <Link href="/api/parse/">`parse`</Link> instead.
+
+```ts
+// Change this
+await validateOrReject(user);
+
+// To this
+const output = v.parse(UserSchema, input);
+```
+
+We recommend that you read our <Link href="../mental-model/">mental model</Link> guide to understand how the individual functions of Valibot's modular API work together.
+
+## Optional properties
+
+The `@IsOptional` decorator skips validation when the value is `null` or `undefined`. This matches Valibot's <Link href="/api/nullish/">`nullish`</Link> schema. If a property can only be `undefined` but not `null`, use <Link href="/api/optional/">`optional`</Link> instead.
+
+```ts
+// Change this
+class Profile {
+  @IsOptional()
+  @IsString()
+  bio?: string;
+}
+
+// To this
+const ProfileSchema = v.object({
+  bio: v.nullish(v.string()),
+});
+```
+
+## Nested objects and arrays
+
+Instead of `@ValidateNested` in combination with class-transformer's `@Type` decorator, you nest schemas directly. For arrays, the `{ each: true }` option is replaced by wrapping the item schema with <Link href="/api/array/">`array`</Link>.
+
+```ts
+// Change this
+class Order {
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => Item)
+  items: Item[];
+}
+
+// To this
+const OrderSchema = v.object({
+  items: v.array(ItemSchema),
+});
+```
+
+## Change names
+
+The following table shows how the most common decorators and methods map to Valibot's API.
+
+| class-validator    | Valibot                                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `@Contains`        | <Link href="/api/includes/">`includes`</Link>                                                                                                           |
+| `@IsArray`         | <Link href="/api/array/">`array`</Link>                                                                                                                 |
+| `@IsBase64`        | <Link href="/api/base64/">`base64`</Link>                                                                                                               |
+| `@IsBoolean`       | <Link href="/api/boolean/">`boolean`</Link>                                                                                                             |
+| `@IsCreditCard`    | <Link href="/api/creditCard/">`creditCard`</Link>                                                                                                       |
+| `@IsDateString`    | <Link href="/api/isoDate/">`isoDate`</Link>, <Link href="/api/isoDateTime/">`isoDateTime`</Link>, <Link href="/api/isoTimestamp/">`isoTimestamp`</Link> |
+| `@IsDefined`       | Default behavior of every schema                                                                                                                        |
+| `@IsEmail`         | <Link href="/api/email/">`email`</Link>                                                                                                                 |
+| `@IsEnum`          | <Link href="/api/enum/">`enum`</Link>                                                                                                                   |
+| `@IsHexadecimal`   | <Link href="/api/hexadecimal/">`hexadecimal`</Link>                                                                                                     |
+| `@IsIn`            | <Link href="/api/picklist/">`picklist`</Link>                                                                                                           |
+| `@IsInt`           | <Link href="/api/number/">`number`</Link> with <Link href="/api/integer/">`integer`</Link>                                                              |
+| `@IsIP`            | <Link href="/api/ip/">`ip`</Link>, <Link href="/api/ipv4/">`ipv4`</Link>, <Link href="/api/ipv6/">`ipv6`</Link>                                         |
+| `@IsNegative`      | <Link href="/api/ltValue/">`ltValue`</Link>                                                                                                             |
+| `@IsNotEmpty`      | <Link href="/api/nonEmpty/">`nonEmpty`</Link>                                                                                                           |
+| `@IsNotIn`         | <Link href="/api/notValues/">`notValues`</Link>                                                                                                         |
+| `@IsNumber`        | <Link href="/api/number/">`number`</Link>                                                                                                               |
+| `@IsOptional`      | <Link href="/api/nullish/">`nullish`</Link>                                                                                                             |
+| `@IsPositive`      | <Link href="/api/gtValue/">`gtValue`</Link>                                                                                                             |
+| `@IsString`        | <Link href="/api/string/">`string`</Link>                                                                                                               |
+| `@IsUrl`           | <Link href="/api/url/">`url`</Link>                                                                                                                     |
+| `@IsUUID`          | <Link href="/api/uuid/">`uuid`</Link>                                                                                                                   |
+| `@Length`          | <Link href="/api/minLength/">`minLength`</Link> with <Link href="/api/maxLength/">`maxLength`</Link>                                                    |
+| `@Matches`         | <Link href="/api/regex/">`regex`</Link>                                                                                                                 |
+| `@Max`             | <Link href="/api/maxValue/">`maxValue`</Link>                                                                                                           |
+| `@MaxLength`       | <Link href="/api/maxLength/">`maxLength`</Link>                                                                                                         |
+| `@Min`             | <Link href="/api/minValue/">`minValue`</Link>                                                                                                           |
+| `@MinLength`       | <Link href="/api/minLength/">`minLength`</Link>                                                                                                         |
+| `@Validate`        | <Link href="/api/check/">`check`</Link>, <Link href="/api/checkAsync/">`checkAsync`</Link>                                                              |
+| `@ValidateNested`  | Nested schema                                                                                                                                           |
+| `validate`         | <Link href="/api/safeParse/">`safeParse`</Link>                                                                                                         |
+| `validateOrReject` | <Link href="/api/parse/">`parse`</Link>                                                                                                                 |
+| `validateSync`     | <Link href="/api/safeParse/">`safeParse`</Link>                                                                                                         |
+
+Many more specific decorators like `@IsMobilePhone` are backed by [validator.js](https://github.com/validatorjs/validator.js). For those without a direct Valibot equivalent, you can use <Link href="/api/check/">`check`</Link> or <Link href="/api/regex/">`regex`</Link> to implement the same validation.
+
+## Other details
+
+Below are some more details that may be helpful when migrating from class-validator to Valibot.
+
+### Unknown properties
+
+By default, class-validator keeps properties without decorators on the instance. This matches <Link href="/api/looseObject/">`looseObject`</Link>. The `whitelist: true` option, which strips unknown properties, matches the default behavior of <Link href="/api/object/">`object`</Link>. The `forbidNonWhitelisted: true` option, which rejects them, matches <Link href="/api/strictObject/">`strictObject`</Link>. See the <Link href="../objects/">objects</Link> guide for more details.
+
+```ts
+// Change this
+const errors = await validate(post, {
+  whitelist: true,
+  forbidNonWhitelisted: true,
+});
+
+// To this
+const result = v.safeParse(v.strictObject({ title: v.string() }), input);
+```
+
+### Custom error messages
+
+Instead of the `message` property in the decorator options, you pass a single string as the first argument to schemas and as the last argument to actions. See the <Link href="../quick-start/#error-messages">quick start</Link> guide for more details.
+
+```ts
+// Change this
+class Login {
+  @MinLength(8, { message: 'Password is too short' })
+  password: string;
+}
+
+// To this
+const LoginSchema = v.object({
+  password: v.pipe(v.string(), v.minLength(8, 'Password is too short')),
+});
+```
+
+### Validation options
+
+Some validation options map to Valibot as follows. The `skipMissingProperties` option corresponds to wrapping your schema with <Link href="/api/partial/">`partial`</Link>. The `stopAtFirstError` option corresponds to the `abortEarly` configuration of <Link href="/api/parse/">`parse`</Link> and <Link href="/api/safeParse/">`safeParse`</Link>. Validation groups have no direct equivalent. Instead, we recommend deriving multiple schemas from a shared object with methods like <Link href="/api/pick/">`pick`</Link>, <Link href="/api/omit/">`omit`</Link> and <Link href="/api/partial/">`partial`</Link>.
+
+### Framework integration
+
+If you use class-validator through a framework like NestJS, you can replace its validation pipe with a custom pipe that calls <Link href="/api/parse/">`parse`</Link> with your schema. See the <Link href="../integrate-valibot/">integration</Link> guide for an overview of ecosystem integrations.

--- a/website/src/routes/guides/(migration)/migrate-from-class-validator/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-class-validator/index.mdx
@@ -197,7 +197,7 @@ const LoginSchema = v.object({
 
 ### Validation options
 
-Some validation options map to Valibot as follows. The `skipMissingProperties` option corresponds to wrapping your schema with <Link href="/api/partial/">`partial`</Link>. The `stopAtFirstError` option corresponds to the `abortEarly` configuration of <Link href="/api/parse/">`parse`</Link> and <Link href="/api/safeParse/">`safeParse`</Link>. Validation groups have no direct equivalent. Instead, we recommend deriving multiple schemas from a shared object with methods like <Link href="/api/pick/">`pick`</Link>, <Link href="/api/omit/">`omit`</Link> and <Link href="/api/partial/">`partial`</Link>.
+Some validation options map only approximately to Valibot and require attention to details. The `skipMissingProperties` option skips properties that are `null` or `undefined`, except for those marked with `@IsDefined`. Wrapping your schema with <Link href="/api/partial/">`partial`</Link> comes close, but only allows `undefined` and affects every entry. For full parity, wrap the individual entries with <Link href="/api/nullish/">`nullish`</Link> instead. The `stopAtFirstError` option stops after the first error of each property, but still reports every invalid property. Valibot's `abortEarly` configuration is stricter and stops after the first issue overall. Validation groups have no direct equivalent. Instead, we recommend deriving multiple schemas from a shared object with methods like <Link href="/api/pick/">`pick`</Link>, <Link href="/api/omit/">`omit`</Link> and <Link href="/api/partial/">`partial`</Link>.
 
 ### Framework integration
 

--- a/website/src/routes/guides/(migration)/migrate-from-io-ts/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-io-ts/index.mdx
@@ -1,0 +1,168 @@
+---
+title: Migrate from io-ts
+description: >-
+  Migrating from io-ts to Valibot is straightforward in most cases since both
+  libraries build schemas by composing small functions.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from io-ts
+
+Migrating from [io-ts](https://github.com/gcanti/io-ts) to Valibot is straightforward in most cases since both libraries build schemas by composing small functions. A big difference is that Valibot does not depend on fp-ts. Instead of working with `Either` and functional combinators, you work with plain result objects. The following guide will help you migrate step by step and also point out important differences.
+
+## Replace imports
+
+The first thing to do after <Link href="../installation/">installing</Link> Valibot is to update your imports. Just change your io-ts imports to Valibot's and replace all occurrences of `t.` with `v.`. The imports from fp-ts are no longer needed.
+
+```ts
+// Change this
+import * as t from 'io-ts';
+import { isRight } from 'fp-ts/Either';
+const Schema = t.type({ key: t.string });
+
+// To this
+import * as v from 'valibot';
+const Schema = v.looseObject({ key: v.string() });
+```
+
+## Restructure code
+
+Instead of calling `.decode` on the codec, you pass the schema as the first argument to <Link href="/api/safeParse/">`safeParse`</Link>. Where io-ts returns an `Either` that you inspect with `isRight` or `fold`, Valibot returns a result object with a `success` property that narrows the type when checked.
+
+```ts
+// Change this
+const result = Schema.decode(input);
+if (isRight(result)) {
+  console.log(result.right);
+} else {
+  console.log(PathReporter.report(result));
+}
+
+// To this
+const result = v.safeParse(Schema, input);
+if (result.success) {
+  console.log(result.output);
+} else {
+  console.log(v.summarize(result.issues));
+}
+```
+
+If you prefer an exception to be thrown on invalid input, use <Link href="/api/parse/">`parse`</Link> instead. The `.is` method of a codec maps directly to the <Link href="/api/is/">`is`</Link> method.
+
+```ts
+// Change this
+if (Schema.is(input)) {
+  // input is typed
+}
+
+// To this
+if (v.is(Schema, input)) {
+  // input is typed
+}
+```
+
+To further validate a value, io-ts uses `t.brand` or `t.refinement`. In Valibot you use <Link href="../pipelines/">pipelines</Link> instead. This is a function that starts with a schema and is followed by up to 19 validation or transformation actions.
+
+```ts
+// Change this
+const Positive = t.brand(
+  t.number,
+  (input): input is t.Branded<number, PositiveBrand> => input > 0,
+  'Positive'
+);
+
+// To this
+const Positive = v.pipe(
+  v.number(),
+  v.check((input) => input > 0),
+  v.brand('Positive')
+);
+```
+
+We recommend that you read our <Link href="../mental-model/">mental model</Link> guide to understand how the individual functions of Valibot's modular API work together.
+
+## Optional properties
+
+io-ts has no dedicated way to mark a single property as optional. The common workaround is an intersection of `t.type` and `t.partial`. In Valibot, you simply wrap optional entries with <Link href="/api/optional/">`optional`</Link>, which usually reduces the schema to a single object.
+
+```ts
+// Change this
+const Schema = t.intersection([
+  t.type({ name: t.string }),
+  t.partial({ age: t.number }),
+]);
+
+// To this
+const Schema = v.looseObject({
+  name: v.string(),
+  age: v.optional(v.number()),
+});
+```
+
+## Change names
+
+Many of the names are the same as in io-ts. However, there are some exceptions. The following table shows all names that have changed.
+
+| io-ts           | Valibot                                                                                      |
+| --------------- | -------------------------------------------------------------------------------------------- |
+| `brand`         | <Link href="/api/check/">`check`</Link> with <Link href="/api/brand/">`brand`</Link>         |
+| `decode`        | <Link href="/api/safeParse/">`safeParse`</Link>, <Link href="/api/parse/">`parse`</Link>     |
+| `exact`         | <Link href="/api/object/">`object`</Link>                                                    |
+| `Int`           | <Link href="/api/number/">`number`</Link> with <Link href="/api/integer/">`integer`</Link>   |
+| `interface`     | <Link href="/api/looseObject/">`looseObject`</Link>                                          |
+| `intersection`  | <Link href="/api/intersect/">`intersect`</Link>                                              |
+| `keyof`         | <Link href="/api/picklist/">`picklist`</Link>                                                |
+| `OutputOf`      | <Link href="/api/InferInput/">`InferInput`</Link>                                            |
+| `PathReporter`  | <Link href="/api/summarize/">`summarize`</Link>, <Link href="/api/flatten/">`flatten`</Link> |
+| `readonlyArray` | <Link href="/api/array/">`array`</Link> with <Link href="/api/readonly/">`readonly`</Link>   |
+| `recursion`     | <Link href="/api/lazy/">`lazy`</Link>                                                        |
+| `refinement`    | <Link href="/api/check/">`check`</Link>                                                      |
+| `strict`        | <Link href="/api/object/">`object`</Link>                                                    |
+| `type`          | <Link href="/api/looseObject/">`looseObject`</Link>                                          |
+| `TypeOf`        | <Link href="/api/InferOutput/">`InferOutput`</Link>                                          |
+| `UnknownArray`  | <Link href="/api/array/">`array`</Link> with <Link href="/api/unknown/">`unknown`</Link>     |
+| `UnknownRecord` | <Link href="/api/record/">`record`</Link> with <Link href="/api/unknown/">`unknown`</Link>   |
+
+## Other details
+
+Below are some more details that may be helpful when migrating from io-ts to Valibot.
+
+### Unknown object keys
+
+io-ts keeps unknown keys when validating objects with `t.type` and removes them when the codec is wrapped with `t.exact` or created with `t.strict`. Valibot's <Link href="/api/looseObject/">`looseObject`</Link> and <Link href="/api/object/">`object`</Link> schemas match these two behaviors. In addition, <Link href="/api/strictObject/">`strictObject`</Link> allows you to reject unknown keys entirely, which io-ts does not support out of the box. See the <Link href="../objects/">objects</Link> guide for more details.
+
+```ts
+// Change this
+const Schema = t.strict({ key: t.string });
+
+// To this
+const Schema = v.object({ key: v.string() });
+```
+
+### Custom codecs
+
+Custom codecs created with `new t.Type` are usually replaced by a pipeline that validates the input and then transforms it. Note that Valibot only covers the decode direction. There is no equivalent to `.encode`, as Valibot does not support transforming in the reverse direction.
+
+```ts
+// Change this
+const DateFromString = new t.Type<Date, string, unknown>(
+  'DateFromString',
+  (input): input is Date => input instanceof Date,
+  (input, context) => {
+    if (typeof input !== 'string') return t.failure(input, context);
+    const date = new Date(input);
+    return isNaN(date.getTime()) ? t.failure(input, context) : t.success(date);
+  },
+  (date) => date.toISOString()
+);
+
+// To this
+const DateFromString = v.pipe(v.string(), v.isoTimestamp(), v.toDate());
+```
+
+### Async validation
+
+The core of io-ts is synchronous. Valibot additionally provides dedicated async functions like <Link href="/api/pipeAsync/">`pipeAsync`</Link> and <Link href="/api/checkAsync/">`checkAsync`</Link> that allow you to run asynchronous logic, such as database checks, as part of your schema. See the <Link href="../async-validation/">async guide</Link> for more details.

--- a/website/src/routes/guides/(migration)/migrate-from-joi/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-joi/index.mdx
@@ -122,13 +122,13 @@ const NumberSchema = v.pipe(v.string(), v.toNumber());
 
 ```ts
 // Change this
-const DateSchema = Joi.date().iso();
+const DateSchema = Joi.date();
 
 // To this
 const DateSchema = v.pipe(v.string(), v.toDate());
 ```
 
-For stricter validation, we recommend adding actions like <Link href="/api/decimal/">`decimal`</Link> or <Link href="/api/isoTimestamp/">`isoTimestamp`</Link> to validate the formatting of the string before converting it.
+Keep in mind that <Link href="/api/toNumber/">`toNumber`</Link> behaves like JavaScript's `Number` function and therefore converts empty strings to `0`, and that <Link href="/api/toDate/">`toDate`</Link> accepts any string that the `Date` constructor can parse. For stricter validation, we recommend adding actions like <Link href="/api/decimal/">`decimal`</Link> or <Link href="/api/isoTimestamp/">`isoTimestamp`</Link> to validate the formatting of the string before converting it.
 
 ```ts
 const NumberSchema = v.pipe(v.string(), v.decimal(), v.toNumber());

--- a/website/src/routes/guides/(migration)/migrate-from-joi/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-joi/index.mdx
@@ -1,0 +1,285 @@
+---
+title: Migrate from Joi
+description: >-
+  Migrating from Joi to Valibot is straightforward in most cases since both
+  APIs share the same basic concepts.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from Joi
+
+Migrating from [Joi](https://joi.dev/) to Valibot is straightforward in most cases since both APIs share the same basic concepts. Beyond a much smaller bundle size, one of the biggest benefits of migrating is that Valibot infers the TypeScript type of your data from your schema, which eliminates the need to maintain separate type definitions. The following guide will help you migrate step by step and also point out important differences.
+
+## Replace imports
+
+The first thing to do after <Link href="../installation/">installing</Link> Valibot is to update your imports. Just change your Joi imports to Valibot's and replace all occurrences of `Joi.` with `v.`.
+
+```ts
+// Change this
+import Joi from 'joi';
+const Schema = Joi.object({ key: Joi.string().required() });
+
+// To this
+import * as v from 'valibot';
+const Schema = v.object({ key: v.string() });
+```
+
+## Restructure code
+
+One of the biggest differences between Joi and Valibot is the way you further validate a given type. In Joi, you chain methods like `.email` and `.max`. In Valibot you use <Link href="../pipelines/">pipelines</Link> to do the same thing. This is a function that starts with a schema and is followed by up to 19 validation or transformation actions.
+
+```ts
+// Change this
+const Schema = Joi.string().email().max(30);
+
+// To this
+const Schema = v.pipe(v.string(), v.email(), v.maxLength(30));
+```
+
+Due to the modular design of Valibot, also all other methods like `.validate` have to be used a little bit differently. Instead of chaining them, you usually pass the schema as the first argument and move any existing arguments one position to the right. Where Joi returns an object with `value` and `error`, <Link href="/api/safeParse/">`safeParse`</Link> returns a result object with `output` and `issues`.
+
+```ts
+// Change this
+const { value, error } = Joi.string().validate('foo');
+
+// To this
+const result = v.safeParse(v.string(), 'foo');
+if (result.success) {
+  console.log(result.output);
+} else {
+  console.log(result.issues);
+}
+```
+
+If you prefer an exception to be thrown on invalid input, as with `Joi.attempt` or `Joi.assert`, use <Link href="/api/parse/">`parse`</Link> instead.
+
+```ts
+// Change this
+const value = Joi.attempt('foo', Joi.string());
+
+// To this
+const value = v.parse(v.string(), 'foo');
+```
+
+We recommend that you read our <Link href="../mental-model/">mental model</Link> guide to understand how the individual functions of Valibot's modular API work together.
+
+## Infer types
+
+Joi does not infer TypeScript types from your schemas, which usually forces you to maintain separate type definitions. With Valibot, you can remove these duplicate definitions and infer the types directly from your schemas. See the <Link href="../infer-types/">infer types</Link> guide for more details.
+
+```ts
+const UserSchema = v.object({
+  name: v.string(),
+  email: v.pipe(v.string(), v.email()),
+});
+
+type User = v.InferOutput<typeof UserSchema>;
+// { name: string; email: string }
+```
+
+## Required by default
+
+Joi schemas are optional by default. To reject `undefined`, you have to append `.required()` to each schema. Valibot works the other way around. Every schema is required by default, and you explicitly mark schemas as optional by wrapping them with <Link href="/api/optional/">`optional`</Link>, <Link href="/api/nullable/">`nullable`</Link> or <Link href="/api/nullish/">`nullish`</Link>.
+
+```ts
+// Change this
+const Schema = Joi.object({
+  name: Joi.string().required(),
+  email: Joi.string(),
+});
+
+// To this
+const Schema = v.object({
+  name: v.string(),
+  email: v.optional(v.string()),
+});
+```
+
+There is one detail to watch out for. Joi's string schema rejects empty strings by default. If you rely on this behavior, add the <Link href="/api/nonEmpty/">`nonEmpty`</Link> action to your pipeline.
+
+```ts
+// Change this
+const Schema = Joi.string().required();
+
+// To this
+const Schema = v.pipe(v.string(), v.nonEmpty());
+```
+
+## No implicit type conversion
+
+By default, Joi converts values to the expected type before validating them. For example, `Joi.number()` accepts the string `'24'` and converts it to the number `24`, and `Joi.date()` converts ISO strings to `Date` objects. Valibot never changes your data implicitly. If you rely on type conversion, use a pipeline with an explicit <Link href="/api/transform/">`transform`</Link> action or one of the dedicated transformation actions like <Link href="/api/toNumber/">`toNumber`</Link> or <Link href="/api/toDate/">`toDate`</Link>. This forces you to explicitly define the input, resulting in safer code.
+
+```ts
+// Change this
+const NumberSchema = Joi.number();
+
+// To this
+const NumberSchema = v.pipe(v.string(), v.toNumber());
+```
+
+```ts
+// Change this
+const DateSchema = Joi.date().iso();
+
+// To this
+const DateSchema = v.pipe(v.string(), v.toDate());
+```
+
+For stricter validation, we recommend adding actions like <Link href="/api/decimal/">`decimal`</Link> or <Link href="/api/isoTimestamp/">`isoTimestamp`</Link> to validate the formatting of the string before converting it.
+
+```ts
+const NumberSchema = v.pipe(v.string(), v.decimal(), v.toNumber());
+const DateSchema = v.pipe(v.string(), v.isoTimestamp(), v.toDate());
+```
+
+## Collect all issues
+
+Another difference is that Joi stops validation after the first error by default. Valibot collects all issues instead. If you prefer Joi's behavior for performance reasons, you can pass a configuration object with `abortEarly: true` as the third argument to <Link href="/api/parse/">`parse`</Link> or <Link href="/api/safeParse/">`safeParse`</Link>.
+
+```ts
+// Change this
+const { error } = Schema.validate(input);
+
+// To this
+const result = v.safeParse(Schema, input, { abortEarly: true });
+```
+
+## Change names
+
+Most of the names are similar to Joi. However, there are some exceptions. The following table shows all names that have changed.
+
+| Joi             | Valibot                                                                                                                                                 |
+| --------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `allow(null)`   | <Link href="/api/nullable/">`nullable`</Link>                                                                                                           |
+| `alphanum`      | <Link href="/api/regex/">`regex`</Link>                                                                                                                 |
+| `alternatives`  | <Link href="/api/union/">`union`</Link>, <Link href="/api/variant/">`variant`</Link>                                                                    |
+| `append`        | <Link href="../intersections/#merge-objects">Object merging</Link>                                                                                      |
+| `assert`        | <Link href="/api/parse/">`parse`</Link>                                                                                                                 |
+| `attempt`       | <Link href="/api/parse/">`parse`</Link>                                                                                                                 |
+| `concat`        | <Link href="../intersections/#merge-objects">Object merging</Link>                                                                                      |
+| `custom`        | <Link href="/api/check/">`check`</Link>, <Link href="/api/rawCheck/">`rawCheck`</Link>, <Link href="/api/rawTransform/">`rawTransform`</Link>           |
+| `default`       | <Link href="/api/optional/">`optional`</Link>                                                                                                           |
+| `equal`         | <Link href="/api/literal/">`literal`</Link>, <Link href="/api/picklist/">`picklist`</Link>                                                              |
+| `external`      | <Link href="/api/checkAsync/">`checkAsync`</Link>                                                                                                       |
+| `forbidden`     | <Link href="/api/optional/">`optional`</Link> with <Link href="/api/never/">`never`</Link>                                                              |
+| `greater`       | <Link href="/api/gtValue/">`gtValue`</Link>                                                                                                             |
+| `guid`          | <Link href="/api/uuid/">`uuid`</Link>                                                                                                                   |
+| `hex`           | <Link href="/api/hexadecimal/">`hexadecimal`</Link>                                                                                                     |
+| `invalid`       | <Link href="/api/notValue/">`notValue`</Link>, <Link href="/api/notValues/">`notValues`</Link>                                                          |
+| `isoDate`       | <Link href="/api/isoDate/">`isoDate`</Link>, <Link href="/api/isoDateTime/">`isoDateTime`</Link>, <Link href="/api/isoTimestamp/">`isoTimestamp`</Link> |
+| `items`         | Item argument of <Link href="/api/array/">`array`</Link>                                                                                                |
+| `keys`          | <Link href="../intersections/#merge-objects">Object merging</Link>                                                                                      |
+| `length`        | <Link href="/api/length/">`length`</Link>, <Link href="/api/size/">`size`</Link>, <Link href="/api/entries/">`entries`</Link>                           |
+| `less`          | <Link href="/api/ltValue/">`ltValue`</Link>                                                                                                             |
+| `link`          | <Link href="/api/lazy/">`lazy`</Link>                                                                                                                   |
+| `lowercase`     | <Link href="/api/toLowerCase/">`toLowerCase`</Link>                                                                                                     |
+| `max`           | <Link href="/api/maxLength/">`maxLength`</Link>, <Link href="/api/maxValue/">`maxValue`</Link>, <Link href="/api/maxEntries/">`maxEntries`</Link>       |
+| `min`           | <Link href="/api/minLength/">`minLength`</Link>, <Link href="/api/minValue/">`minValue`</Link>, <Link href="/api/minEntries/">`minEntries`</Link>       |
+| `multiple`      | <Link href="/api/multipleOf/">`multipleOf`</Link>                                                                                                       |
+| `negative`      | <Link href="/api/ltValue/">`ltValue`</Link>                                                                                                             |
+| `ordered`       | <Link href="/api/tuple/">`tuple`</Link>, <Link href="/api/tupleWithRest/">`tupleWithRest`</Link>                                                        |
+| `pattern`       | <Link href="/api/regex/">`regex`</Link>, <Link href="/api/record/">`record`</Link>, <Link href="/api/objectWithRest/">`objectWithRest`</Link>           |
+| `positive`      | <Link href="/api/gtValue/">`gtValue`</Link>                                                                                                             |
+| `try`           | <Link href="/api/union/">`union`</Link>, <Link href="/api/variant/">`variant`</Link>                                                                    |
+| `unique`        | <Link href="/api/checkItems/">`checkItems`</Link>                                                                                                       |
+| `unknown`       | <Link href="/api/looseObject/">`looseObject`</Link>                                                                                                     |
+| `uppercase`     | <Link href="/api/toUpperCase/">`toUpperCase`</Link>                                                                                                     |
+| `uri`           | <Link href="/api/url/">`url`</Link>                                                                                                                     |
+| `valid`         | <Link href="/api/literal/">`literal`</Link>, <Link href="/api/picklist/">`picklist`</Link>                                                              |
+| `validate`      | <Link href="/api/parse/">`parse`</Link>, <Link href="/api/safeParse/">`safeParse`</Link>                                                                |
+| `validateAsync` | <Link href="/api/parseAsync/">`parseAsync`</Link>, <Link href="/api/safeParseAsync/">`safeParseAsync`</Link>                                            |
+
+## Other details
+
+Below are some more details that may be helpful when migrating from Joi to Valibot.
+
+### Unknown object keys
+
+By default, Joi rejects unknown keys when validating objects. This matches Valibot's <Link href="/api/strictObject/">`strictObject`</Link> schema. If you use `.unknown()` to keep unknown keys, use <Link href="/api/looseObject/">`looseObject`</Link> instead. If you use the `stripUnknown` option to remove them, <Link href="/api/object/">`object`</Link> is the right choice. See the <Link href="../objects/">objects</Link> guide for more details.
+
+```ts
+// Change this
+const ObjectSchema = Joi.object({ key: Joi.string().required() });
+
+// To this
+const ObjectSchema = v.strictObject({ key: v.string() });
+```
+
+### Cross-field validation
+
+Joi uses `Joi.ref` to reference the value of another field, for example to check that two passwords match. In Valibot, you use a pipeline on the object schema with <Link href="/api/forward/">`forward`</Link> and <Link href="/api/partialCheck/">`partialCheck`</Link> instead.
+
+```ts
+// Change this
+const RegisterSchema = Joi.object({
+  password: Joi.string().required(),
+  confirmPassword: Joi.string()
+    .required()
+    .valid(Joi.ref('password'))
+    .messages({ 'any.only': 'The two passwords do not match.' }),
+});
+
+// To this
+const RegisterSchema = v.pipe(
+  v.object({
+    password: v.pipe(v.string(), v.nonEmpty()),
+    confirmPassword: v.pipe(v.string(), v.nonEmpty()),
+  }),
+  v.forward(
+    v.partialCheck(
+      [['password'], ['confirmPassword']],
+      (input) => input.password === input.confirmPassword,
+      'The two passwords do not match.'
+    ),
+    ['confirmPassword']
+  )
+);
+```
+
+### Conditional schemas
+
+There is no direct equivalent to Joi's `.when()` method. For discriminated unions, we recommend <Link href="/api/variant/">`variant`</Link>. For other conditional validations, you can use <Link href="/api/check/">`check`</Link> or <Link href="/api/rawCheck/">`rawCheck`</Link> on the parent object, or select the schema dynamically with <Link href="/api/lazy/">`lazy`</Link>, which receives the current input as an argument.
+
+### Error messages
+
+Instead of `.messages()`, `.message()` and `.label()`, you pass a single string as the first argument to schemas and as the last argument to actions. See the <Link href="../quick-start/#error-messages">quick start</Link> and <Link href="../internationalization/">internationalization</Link> guide for more details.
+
+```ts
+// Change this
+const Schema = Joi.string().min(10).messages({
+  'string.base': 'Must be a string',
+  'string.min': 'String is too short',
+});
+
+// To this
+const Schema = v.pipe(
+  v.string('Must be a string'),
+  v.minLength(10, 'String is too short')
+);
+```
+
+### Async validation
+
+Joi's `.external()` method allows asynchronous validation rules. Valibot provides dedicated async functions like <Link href="/api/parseAsync/">`parseAsync`</Link>, <Link href="/api/pipeAsync/">`pipeAsync`</Link> and <Link href="/api/checkAsync/">`checkAsync`</Link> for this purpose. See the <Link href="../async-validation/">async guide</Link> for more details.
+
+```ts
+// Change this
+const Schema = Joi.string().external(async (value) => {
+  if (await isUsernameTaken(value)) {
+    throw new Error('Username is already taken');
+  }
+  return value;
+});
+
+// To this
+const Schema = v.pipeAsync(
+  v.string(),
+  v.checkAsync(
+    async (input) => !(await isUsernameTaken(input)),
+    'Username is already taken'
+  )
+);
+```

--- a/website/src/routes/guides/(migration)/migrate-from-superstruct/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-superstruct/index.mdx
@@ -1,0 +1,150 @@
+---
+title: Migrate from Superstruct
+description: >-
+  Migrating from Superstruct to Valibot is particularly easy since both
+  libraries share the same functional and composable design.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from Superstruct
+
+Migrating from [Superstruct](https://github.com/ianstormtaylor/superstruct) to Valibot is particularly easy since both libraries share the same functional and composable design. Most structs map directly to a Valibot schema. The following guide will help you migrate step by step and also point out important differences.
+
+## Replace imports
+
+The first thing to do after <Link href="../installation/">installing</Link> Valibot is to update your imports. We recommend importing Valibot with a wildcard, which gives you access to the entire API through a single variable while remaining fully tree-shakable.
+
+```ts
+// Change this
+import { object, string, assert } from 'superstruct';
+const Schema = object({ key: string() });
+
+// To this
+import * as v from 'valibot';
+const Schema = v.strictObject({ key: v.string() });
+```
+
+There is one detail to watch out for. Superstruct's methods expect the value as the first argument and the struct as the second. In Valibot, the schema always comes first.
+
+```ts
+// Change this
+assert(input, Schema);
+
+// To this
+v.assert(Schema, input);
+```
+
+## Restructure code
+
+Superstruct wraps structs with refinement functions like `size` and `pattern`. In Valibot you use <Link href="../pipelines/">pipelines</Link> to do the same thing. This is a function that starts with a schema and is followed by up to 19 validation or transformation actions.
+
+```ts
+// Change this
+const Schema = size(pattern(string(), /^[a-z]+$/), 3, 30);
+
+// To this
+const Schema = v.pipe(
+  v.string(),
+  v.regex(/^[a-z]+$/),
+  v.minLength(3),
+  v.maxLength(30)
+);
+```
+
+The validation methods map almost one-to-one. `assert` keeps its name, `is` keeps its name with flipped arguments, `validate` returns a result object with <Link href="/api/safeParse/">`safeParse`</Link>, and `create` becomes <Link href="/api/parse/">`parse`</Link>.
+
+```ts
+// Change this
+const [error, value] = validate(input, Schema);
+
+// To this
+const result = v.safeParse(Schema, input);
+if (result.success) {
+  console.log(result.output);
+} else {
+  console.log(result.issues);
+}
+```
+
+We recommend that you read our <Link href="../mental-model/">mental model</Link> guide to understand how the individual functions of Valibot's modular API work together.
+
+## Coercion and defaults
+
+Superstruct separates validation from coercion. Coercions and defaults defined with `coerce`, `defaulted` and `trimmed` are only applied when calling `create`, but not when calling `assert` or `is`. Valibot does not make this distinction. Transformations and default values are part of the schema and are always applied when parsing.
+
+```ts
+// Change this
+const Schema = defaulted(trimmed(string()), 'foo');
+const value = create(input, Schema);
+
+// To this
+const Schema = v.optional(v.pipe(v.string(), v.trim()), 'foo');
+const value = v.parse(Schema, input);
+```
+
+For type coercions defined with `coerce`, use a pipeline with an explicit <Link href="/api/transform/">`transform`</Link> action or one of the dedicated transformation actions like <Link href="/api/toNumber/">`toNumber`</Link> or <Link href="/api/toDate/">`toDate`</Link>.
+
+```ts
+// Change this
+const Schema = coerce(number(), string(), (value) => parseFloat(value));
+
+// To this
+const Schema = v.pipe(v.string(), v.decimal(), v.toNumber());
+```
+
+## Change names
+
+Most of the names are the same as in Superstruct. However, there are some exceptions. The following table shows all names that have changed.
+
+| Superstruct    | Valibot                                                                                                                                                                                                   |
+| -------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `assign`       | <Link href="../intersections/#merge-objects">Object merging</Link>                                                                                                                                        |
+| `coerce`       | <Link href="/api/pipe/">`pipe`</Link> and <Link href="/api/transform/">`transform`</Link>                                                                                                                 |
+| `create`       | <Link href="/api/parse/">`parse`</Link>                                                                                                                                                                   |
+| `defaulted`    | <Link href="/api/optional/">`optional`</Link>                                                                                                                                                             |
+| `define`       | <Link href="/api/custom/">`custom`</Link>                                                                                                                                                                 |
+| `dynamic`      | <Link href="/api/lazy/">`lazy`</Link>                                                                                                                                                                     |
+| `enums`        | <Link href="/api/picklist/">`picklist`</Link>                                                                                                                                                             |
+| `func`         | <Link href="/api/function/">`function`</Link>                                                                                                                                                             |
+| `Infer`        | <Link href="/api/InferOutput/">`InferOutput`</Link>                                                                                                                                                       |
+| `integer`      | <Link href="/api/number/">`number`</Link> with <Link href="/api/integer/">`integer`</Link>                                                                                                                |
+| `intersection` | <Link href="/api/intersect/">`intersect`</Link>                                                                                                                                                           |
+| `mask`         | <Link href="/api/parse/">`parse`</Link> with <Link href="/api/object/">`object`</Link>                                                                                                                    |
+| `max`          | <Link href="/api/maxValue/">`maxValue`</Link>, <Link href="/api/ltValue/">`ltValue`</Link>                                                                                                                |
+| `min`          | <Link href="/api/minValue/">`minValue`</Link>, <Link href="/api/gtValue/">`gtValue`</Link>                                                                                                                |
+| `nonempty`     | <Link href="/api/nonEmpty/">`nonEmpty`</Link>                                                                                                                                                             |
+| `object`       | <Link href="/api/strictObject/">`strictObject`</Link>                                                                                                                                                     |
+| `pattern`      | <Link href="/api/regex/">`regex`</Link>                                                                                                                                                                   |
+| `refine`       | <Link href="/api/check/">`check`</Link>                                                                                                                                                                   |
+| `size`         | <Link href="/api/minLength/">`minLength`</Link>, <Link href="/api/maxLength/">`maxLength`</Link>, <Link href="/api/minValue/">`minValue`</Link>, <Link href="/api/maxValue/">`maxValue`</Link> and others |
+| `StructError`  | <Link href="/api/ValiError/">`ValiError`</Link>                                                                                                                                                           |
+| `trimmed`      | <Link href="/api/trim/">`trim`</Link>                                                                                                                                                                     |
+| `type`         | <Link href="/api/looseObject/">`looseObject`</Link>                                                                                                                                                       |
+| `validate`     | <Link href="/api/safeParse/">`safeParse`</Link>                                                                                                                                                           |
+
+## Other details
+
+Below are some more details that may be helpful when migrating from Superstruct to Valibot.
+
+### Unknown object keys
+
+Superstruct provides three behaviors for unknown object keys, and each of them has a direct equivalent in Valibot. `object` rejects unknown keys, which matches <Link href="/api/strictObject/">`strictObject`</Link>. `type` allows and keeps unknown keys, which matches <Link href="/api/looseObject/">`looseObject`</Link>. The `mask` method removes unknown keys, which matches the default behavior of <Link href="/api/object/">`object`</Link> when parsing. See the <Link href="../objects/">objects</Link> guide for more details.
+
+```ts
+// Change this
+const value = mask(input, object({ key: string() }));
+
+// To this
+const value = v.parse(v.object({ key: v.string() }), input);
+```
+
+### Error details
+
+Superstruct's `StructError` provides a `failures` method that returns all validation failures. In Valibot, the issues are directly available on the result of <Link href="/api/safeParse/">`safeParse`</Link> or via the `issues` property of a <Link href="/api/ValiError/">`ValiError`</Link>. The <Link href="/api/flatten/">`flatten`</Link>, <Link href="/api/summarize/">`summarize`</Link> and <Link href="/api/getDotPath/">`getDotPath`</Link> methods help you work with them. See the <Link href="../issues/">issues</Link> guide for more details.
+
+### Async validation
+
+Superstruct does not support asynchronous validation. With Valibot, you get it for free. Functions like <Link href="/api/pipeAsync/">`pipeAsync`</Link> and <Link href="/api/checkAsync/">`checkAsync`</Link> allow you to run asynchronous logic, such as database checks, as part of your schema. See the <Link href="../async-validation/">async guide</Link> for more details.

--- a/website/src/routes/guides/(migration)/migrate-from-typebox/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-typebox/index.mdx
@@ -93,7 +93,7 @@ const Schema = v.pipe(v.string(), v.toDate());
 const date = v.parse(Schema, input);
 ```
 
-For stricter validation, we recommend adding actions like <Link href="/api/decimal/">`decimal`</Link> or <Link href="/api/isoTimestamp/">`isoTimestamp`</Link> to validate the formatting of the string before converting it.
+Keep in mind that <Link href="/api/toNumber/">`toNumber`</Link> behaves like JavaScript's `Number` function and therefore converts empty strings to `0`, and that <Link href="/api/toDate/">`toDate`</Link> accepts any string that the `Date` constructor can parse. For stricter validation, we recommend adding actions like <Link href="/api/decimal/">`decimal`</Link> or <Link href="/api/isoTimestamp/">`isoTimestamp`</Link> to validate the formatting of the string before converting it.
 
 ```ts
 const NumberSchema = v.pipe(v.string(), v.decimal(), v.toNumber());
@@ -159,6 +159,24 @@ const ObjectSchema = Type.Object(
 
 // To this
 const ObjectSchema = v.strictObject({ key: v.string() });
+```
+
+### Unique items
+
+Valibot does not provide a dedicated action for JSON Schema's `uniqueItems` keyword. Instead, you can use the <Link href="/api/checkItems/">`checkItems`</Link> action. Its requirement function receives the entire array as its third argument, which allows you to compare each item against the others.
+
+```ts
+// Change this
+const Schema = Type.Array(Type.Number(), { uniqueItems: true });
+
+// To this
+const Schema = v.pipe(
+  v.array(v.number()),
+  v.checkItems(
+    (item, index, array) => array.indexOf(item) === index,
+    'Duplicate items are not allowed'
+  )
+);
 ```
 
 ### Reusable parsers

--- a/website/src/routes/guides/(migration)/migrate-from-typebox/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-typebox/index.mdx
@@ -1,0 +1,196 @@
+---
+title: Migrate from TypeBox
+description: >-
+  Migrating from TypeBox to Valibot is straightforward in most cases since
+  both libraries are type-safe and share the same basic concepts.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from TypeBox
+
+Migrating from [TypeBox](https://github.com/sinclairzx81/typebox) to Valibot is straightforward in most cases since both libraries are type-safe and share the same basic concepts. Like Valibot, TypeBox schemas are required by default, which makes the structure of your schemas easy to map. The following guide will help you migrate step by step and also point out important differences.
+
+## Replace imports
+
+The first thing to do after <Link href="../installation/">installing</Link> Valibot is to update your imports. Since Valibot validates your data itself, the separate imports for the `Value` module or the `TypeCompiler` are no longer needed. To infer the type of a schema, replace `Static` with <Link href="/api/InferOutput/">`InferOutput`</Link>.
+
+```ts
+// Change this
+import { Type, type Static } from '@sinclair/typebox';
+import { Value } from '@sinclair/typebox/value';
+const Schema = Type.Object({ key: Type.String() });
+type Data = Static<typeof Schema>;
+
+// To this
+import * as v from 'valibot';
+const Schema = v.object({ key: v.string() });
+type Data = v.InferOutput<typeof Schema>;
+```
+
+## Restructure code
+
+TypeBox describes constraints with a JSON Schema options object as the last argument. In Valibot you use <Link href="../pipelines/">pipelines</Link> to do the same thing. This is a function that starts with a schema and is followed by up to 19 validation or transformation actions.
+
+```ts
+// Change this
+const Schema = Type.String({ minLength: 3, maxLength: 30 });
+
+// To this
+const Schema = v.pipe(v.string(), v.minLength(3), v.maxLength(30));
+```
+
+To validate or parse data, you pass the schema as the first argument to methods like <Link href="/api/is/">`is`</Link>, <Link href="/api/parse/">`parse`</Link> or <Link href="/api/safeParse/">`safeParse`</Link>.
+
+```ts
+// Change this
+const valid = Value.Check(Schema, input);
+
+// To this
+const valid = v.is(Schema, input);
+```
+
+We recommend that you read our <Link href="../mental-model/">mental model</Link> guide to understand how the individual functions of Valibot's modular API work together.
+
+## String formats
+
+In TypeBox, string formats like `email` must be registered with the `FormatRegistry` before they can be used, or they will fail validation. Valibot ships these validations as actions that work out of the box.
+
+```ts
+// Change this
+FormatRegistry.Set('email', (value) => isEmail(value));
+const Schema = Type.String({ format: 'email' });
+
+// To this
+const Schema = v.pipe(v.string(), v.email());
+```
+
+## No implicit type conversion
+
+TypeBox's `Value.Parse` runs the `Clean`, `Default` and `Convert` operations before asserting the type. This means that it removes unknown object keys and converts values to the expected type. For example, the string `'24'` is converted to the number `24`. In Valibot, this behavior is not controlled by the parsing method, but by the schema itself. The <Link href="/api/object/">`object`</Link> schema removes unknown keys and <Link href="/api/optional/">`optional`</Link> applies default values, but no schema ever converts types implicitly. If you rely on type conversion, use a pipeline with an explicit <Link href="/api/transform/">`transform`</Link> action or one of the dedicated transformation actions like <Link href="/api/toNumber/">`toNumber`</Link> or <Link href="/api/toDate/">`toDate`</Link>. This forces you to explicitly define the input, resulting in safer code.
+
+```ts
+// Change this
+const value = Value.Parse(Type.Number(), input);
+
+// To this
+const value = v.parse(v.pipe(v.string(), v.toNumber()), input);
+```
+
+Similarly, `Type.Transform` with its `Decode` and `Encode` functions is replaced by a pipeline with a <Link href="/api/transform/">`transform`</Link> action. Note that Valibot only transforms in one direction and does not provide an equivalent to `Value.Encode`.
+
+```ts
+// Change this
+const Schema = Type.Transform(Type.String())
+  .Decode((value) => new Date(value))
+  .Encode((value) => value.toISOString());
+const date = Value.Decode(Schema, input);
+
+// To this
+const Schema = v.pipe(v.string(), v.toDate());
+const date = v.parse(Schema, input);
+```
+
+For stricter validation, we recommend adding actions like <Link href="/api/decimal/">`decimal`</Link> or <Link href="/api/isoTimestamp/">`isoTimestamp`</Link> to validate the formatting of the string before converting it.
+
+```ts
+const NumberSchema = v.pipe(v.string(), v.decimal(), v.toNumber());
+const DateSchema = v.pipe(v.string(), v.isoTimestamp(), v.toDate());
+```
+
+## Change names
+
+Many type builder functions just change to lowercase, such as `Type.String` to <Link href="/api/string/">`string`</Link> or `Type.Object` to <Link href="/api/object/">`object`</Link>. However, there are some exceptions. The following table shows all names that have changed beyond that.
+
+| TypeBox          | Valibot                                                                                      |
+| ---------------- | -------------------------------------------------------------------------------------------- |
+| `Static`         | <Link href="/api/InferOutput/">`InferOutput`</Link>                                          |
+| `StaticDecode`   | <Link href="/api/InferOutput/">`InferOutput`</Link>                                          |
+| `StaticEncode`   | <Link href="/api/InferInput/">`InferInput`</Link>                                            |
+| `Type.Composite` | <Link href="../intersections/#merge-objects">Object merging</Link>                           |
+| `Type.Integer`   | <Link href="/api/number/">`number`</Link> with <Link href="/api/integer/">`integer`</Link>   |
+| `Type.KeyOf`     | <Link href="/api/keyof/">`keyof`</Link>                                                      |
+| `Type.Recursive` | <Link href="/api/lazy/">`lazy`</Link>                                                        |
+| `Type.Transform` | <Link href="/api/pipe/">`pipe`</Link> with <Link href="/api/transform/">`transform`</Link>   |
+| `Type.Unsafe`    | <Link href="/api/custom/">`custom`</Link>                                                    |
+| `TypeCompiler`   | <Link href="/api/parser/">`parser`</Link>, <Link href="/api/safeParser/">`safeParser`</Link> |
+| `Value.Check`    | <Link href="/api/is/">`is`</Link>                                                            |
+| `Value.Decode`   | <Link href="/api/parse/">`parse`</Link>                                                      |
+| `Value.Default`  | <Link href="/api/optional/">`optional`</Link>                                                |
+| `Value.Errors`   | <Link href="/api/safeParse/">`safeParse`</Link>                                              |
+| `Value.Parse`    | <Link href="/api/parse/">`parse`</Link>                                                      |
+
+The same applies to the constraint options. The following table shows how they map to Valibot's actions.
+
+| TypeBox                       | Valibot                                                                                                                        |
+| ----------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `additionalProperties: false` | <Link href="/api/strictObject/">`strictObject`</Link>                                                                          |
+| `additionalProperties: T`     | <Link href="/api/objectWithRest/">`objectWithRest`</Link>                                                                      |
+| `default`                     | <Link href="/api/optional/">`optional`</Link>                                                                                  |
+| `exclusiveMaximum`            | <Link href="/api/ltValue/">`ltValue`</Link>                                                                                    |
+| `exclusiveMinimum`            | <Link href="/api/gtValue/">`gtValue`</Link>                                                                                    |
+| `format`                      | <Link href="/api/email/">`email`</Link>, <Link href="/api/url/">`url`</Link>, <Link href="/api/uuid/">`uuid`</Link> and others |
+| `maximum`                     | <Link href="/api/maxValue/">`maxValue`</Link>                                                                                  |
+| `maxItems`                    | <Link href="/api/maxLength/">`maxLength`</Link>                                                                                |
+| `maxProperties`               | <Link href="/api/maxEntries/">`maxEntries`</Link>                                                                              |
+| `minimum`                     | <Link href="/api/minValue/">`minValue`</Link>                                                                                  |
+| `minItems`                    | <Link href="/api/minLength/">`minLength`</Link>                                                                                |
+| `minProperties`               | <Link href="/api/minEntries/">`minEntries`</Link>                                                                              |
+| `multipleOf`                  | <Link href="/api/multipleOf/">`multipleOf`</Link>                                                                              |
+| `pattern`                     | <Link href="/api/regex/">`regex`</Link>                                                                                        |
+| `uniqueItems`                 | <Link href="/api/checkItems/">`checkItems`</Link>                                                                              |
+
+## Other details
+
+Below are some more details that may be helpful when migrating from TypeBox to Valibot.
+
+### Unknown object keys
+
+Following JSON Schema semantics, TypeBox allows and keeps unknown keys when validating objects by default. Valibot's <Link href="/api/object/">`object`</Link> schema removes them instead, similar to `Value.Clean`. If you rely on TypeBox's behavior, use <Link href="/api/looseObject/">`looseObject`</Link>. To reject unknown keys, as with `additionalProperties: false`, use <Link href="/api/strictObject/">`strictObject`</Link>. See the <Link href="../objects/">objects</Link> guide for more details.
+
+```ts
+// Change this
+const ObjectSchema = Type.Object(
+  { key: Type.String() },
+  { additionalProperties: false }
+);
+
+// To this
+const ObjectSchema = v.strictObject({ key: v.string() });
+```
+
+### Reusable parsers
+
+TypeBox's `TypeCompiler` generates optimized JavaScript code for a schema at runtime. Valibot's schemas are executed directly and do not require a compile step. This also means that Valibot does not evaluate generated code, which allows it to run in environments with a strict Content Security Policy. If you like the ergonomics of a compiled validator, <Link href="/api/parser/">`parser`</Link> and <Link href="/api/safeParser/">`safeParser`</Link> create a reusable function bound to your schema.
+
+```ts
+// Change this
+const Compiled = TypeCompiler.Compile(Schema);
+const valid = Compiled.Check(input);
+
+// To this
+const parseSchema = v.safeParser(Schema);
+const result = parseSchema(input);
+```
+
+### JSON Schema
+
+TypeBox schemas are JSON Schema objects. Valibot schemas are plain JavaScript objects with their own structure. If you need JSON Schema output, for example for OpenAPI definitions or LLM structured outputs, you can use the official `@valibot/to-json-schema` package to convert your Valibot schemas to JSON Schema. See the <Link href="../json-schema/">JSON Schema</Link> guide for more details.
+
+```ts
+import { toJsonSchema } from '@valibot/to-json-schema';
+import * as v from 'valibot';
+
+const ValibotSchema = v.object({
+  name: v.string(),
+  email: v.pipe(v.string(), v.email()),
+});
+
+const jsonSchema = toJsonSchema(ValibotSchema);
+```
+
+### Async validation
+
+Unlike TypeBox, Valibot also supports asynchronous validation, for example for database checks. See the <Link href="../async-validation/">async guide</Link> for more details.

--- a/website/src/routes/guides/(migration)/migrate-from-yup/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-yup/index.mdx
@@ -1,0 +1,214 @@
+---
+title: Migrate from Yup
+description: >-
+  Migrating from Yup to Valibot is straightforward in most cases since both
+  APIs share the same basic concepts.
+contributors:
+  - fabian-hiller
+---
+
+import { Link } from '~/components';
+
+# Migrate from Yup
+
+Migrating from [Yup](https://github.com/jquense/yup) to Valibot is straightforward in most cases since both APIs share the same basic concepts. The following guide will help you migrate step by step and also point out important differences.
+
+## Replace imports
+
+The first thing to do after <Link href="../installation/">installing</Link> Valibot is to update your imports. Just change your Yup imports to Valibot's and replace all occurrences of `yup.` with `v.`.
+
+```ts
+// Change this
+import * as yup from 'yup';
+const Schema = yup.object({ key: yup.string().required() });
+
+// To this
+import * as v from 'valibot';
+const Schema = v.object({ key: v.string() });
+```
+
+## Restructure code
+
+One of the biggest differences between Yup and Valibot is the way you further validate a given type. In Yup, you chain methods like `.email` and `.max`. In Valibot you use <Link href="../pipelines/">pipelines</Link> to do the same thing. This is a function that starts with a schema and is followed by up to 19 validation or transformation actions.
+
+```ts
+// Change this
+const Schema = yup.string().email().max(30);
+
+// To this
+const Schema = v.pipe(v.string(), v.email(), v.maxLength(30));
+```
+
+Due to the modular design of Valibot, also all other methods like `.validate` or `.isValid` have to be used a little bit differently. Instead of chaining them, you usually pass the schema as the first argument and move any existing arguments one position to the right. Note that Yup's `.validate` method is asynchronous by default, whereas <Link href="/api/parse/">`parse`</Link> is synchronous.
+
+```ts
+// Change this
+const value = yup.string().validateSync('foo');
+
+// To this
+const value = v.parse(v.string(), 'foo');
+```
+
+We recommend that you read our <Link href="../mental-model/">mental model</Link> guide to understand how the individual functions of Valibot's modular API work together.
+
+## Required by default
+
+Yup schemas are optional by default. To reject `undefined`, you have to append `.required()` to each schema. Valibot works the other way around. Every schema is required by default, and you explicitly mark schemas as optional by wrapping them with <Link href="/api/optional/">`optional`</Link>, <Link href="/api/nullable/">`nullable`</Link> or <Link href="/api/nullish/">`nullish`</Link>.
+
+```ts
+// Change this
+const Schema = yup.object({
+  name: yup.string().required(),
+  email: yup.string(),
+});
+
+// To this
+const Schema = v.object({
+  name: v.string(),
+  email: v.optional(v.string()),
+});
+```
+
+There is one detail to watch out for. For string schemas, Yup's `.required()` also rejects empty strings. If you rely on this behavior, add the <Link href="/api/nonEmpty/">`nonEmpty`</Link> action to your pipeline.
+
+```ts
+// Change this
+const Schema = yup.string().required();
+
+// To this
+const Schema = v.pipe(v.string(), v.nonEmpty());
+```
+
+## No implicit type coercion
+
+Before validating a value, Yup casts it to the expected type. For example, `yup.number()` accepts the string `'24'` and converts it to the number `24`. This even applies to `.isValid` checks. Valibot never changes your data implicitly. If you rely on type coercion, use a pipeline with an explicit <Link href="/api/transform/">`transform`</Link> action or one of the dedicated transformation actions like <Link href="/api/toNumber/">`toNumber`</Link> or <Link href="/api/toDate/">`toDate`</Link>. This forces you to explicitly define the input, resulting in safer code.
+
+```ts
+// Change this
+const NumberSchema = yup.number();
+
+// To this
+const NumberSchema = v.pipe(v.string(), v.toNumber());
+```
+
+The same applies to dates. Yup's `.cast` method converts ISO strings to `Date` objects. In Valibot, you define this conversion explicitly.
+
+```ts
+// Change this
+const DateSchema = yup.date();
+
+// To this
+const DateSchema = v.pipe(v.string(), v.toDate());
+```
+
+For stricter validation, we recommend adding actions like <Link href="/api/decimal/">`decimal`</Link> or <Link href="/api/isoTimestamp/">`isoTimestamp`</Link> to validate the formatting of the string before converting it.
+
+```ts
+const NumberSchema = v.pipe(v.string(), v.decimal(), v.toNumber());
+const DateSchema = v.pipe(v.string(), v.isoTimestamp(), v.toDate());
+```
+
+## Change names
+
+Most of the names are the same as in Yup. However, there are some exceptions. The following table shows all names that have changed.
+
+| Yup            | Valibot                                                                                                      |
+| -------------- | ------------------------------------------------------------------------------------------------------------ |
+| `bool`         | <Link href="/api/boolean/">`boolean`</Link>                                                                  |
+| `concat`       | <Link href="../intersections/#merge-objects">Object merging</Link>                                           |
+| `default`      | <Link href="/api/optional/">`optional`</Link>                                                                |
+| `InferType`    | <Link href="/api/InferOutput/">`InferOutput`</Link>                                                          |
+| `isValid`      | <Link href="/api/is/">`is`</Link>                                                                            |
+| `json`         | <Link href="/api/parseJson/">`parseJson`</Link>                                                              |
+| `lessThan`     | <Link href="/api/ltValue/">`ltValue`</Link>                                                                  |
+| `matches`      | <Link href="/api/regex/">`regex`</Link>                                                                      |
+| `max`          | <Link href="/api/maxLength/">`maxLength`</Link>, <Link href="/api/maxValue/">`maxValue`</Link>               |
+| `min`          | <Link href="/api/minLength/">`minLength`</Link>, <Link href="/api/minValue/">`minValue`</Link>               |
+| `mixed`        | <Link href="/api/any/">`any`</Link>, <Link href="/api/unknown/">`unknown`</Link>                             |
+| `moreThan`     | <Link href="/api/gtValue/">`gtValue`</Link>                                                                  |
+| `negative`     | <Link href="/api/ltValue/">`ltValue`</Link>                                                                  |
+| `noUnknown`    | <Link href="/api/strictObject/">`strictObject`</Link>                                                        |
+| `notOneOf`     | <Link href="/api/notValues/">`notValues`</Link>                                                              |
+| `notRequired`  | <Link href="/api/nullish/">`nullish`</Link>                                                                  |
+| `of`           | Item argument of <Link href="/api/array/">`array`</Link>                                                     |
+| `oneOf`        | <Link href="/api/picklist/">`picklist`</Link>                                                                |
+| `positive`     | <Link href="/api/gtValue/">`gtValue`</Link>                                                                  |
+| `shape`        | `entries`                                                                                                    |
+| `strip`        | <Link href="/api/omit/">`omit`</Link>                                                                        |
+| `test`         | <Link href="/api/check/">`check`</Link>, <Link href="/api/rawCheck/">`rawCheck`</Link>                       |
+| `typeError`    | Error message argument of schema                                                                             |
+| `validate`     | <Link href="/api/parseAsync/">`parseAsync`</Link>, <Link href="/api/safeParseAsync/">`safeParseAsync`</Link> |
+| `validateSync` | <Link href="/api/parse/">`parse`</Link>, <Link href="/api/safeParse/">`safeParse`</Link>                     |
+
+## Other details
+
+Below are some more details that may be helpful when migrating from Yup to Valibot.
+
+### Unknown object keys
+
+By default, Yup keeps unknown keys when validating objects. Valibot's <Link href="/api/object/">`object`</Link> schema removes them instead. If you rely on Yup's behavior, use <Link href="/api/looseObject/">`looseObject`</Link>. If you use the `stripUnknown` option, <Link href="/api/object/">`object`</Link> is the right choice. To reject unknown keys, as with `.noUnknown()` in combination with `.strict()`, use <Link href="/api/strictObject/">`strictObject`</Link>. See the <Link href="../objects/">objects</Link> guide for more details.
+
+```ts
+// Change this
+const ObjectSchema = yup.object({ key: yup.string().required() });
+
+// To this
+const ObjectSchema = v.looseObject({ key: v.string() });
+```
+
+### Cross-field validation
+
+Yup uses `ref` to reference the value of another field, for example to check that two passwords match. In Valibot, you use a pipeline on the object schema with <Link href="/api/forward/">`forward`</Link> and <Link href="/api/partialCheck/">`partialCheck`</Link> instead.
+
+```ts
+// Change this
+const RegisterSchema = yup.object({
+  password: yup.string().required(),
+  confirmPassword: yup
+    .string()
+    .required()
+    .oneOf([yup.ref('password')], 'The two passwords do not match.'),
+});
+
+// To this
+const RegisterSchema = v.pipe(
+  v.object({
+    password: v.pipe(v.string(), v.nonEmpty()),
+    confirmPassword: v.pipe(v.string(), v.nonEmpty()),
+  }),
+  v.forward(
+    v.partialCheck(
+      [['password'], ['confirmPassword']],
+      (input) => input.password === input.confirmPassword,
+      'The two passwords do not match.'
+    ),
+    ['confirmPassword']
+  )
+);
+```
+
+### Conditional schemas
+
+There is no direct equivalent to Yup's `.when()` method. For discriminated unions, we recommend <Link href="/api/variant/">`variant`</Link>. For other conditional validations, you can use <Link href="/api/check/">`check`</Link> or <Link href="/api/rawCheck/">`rawCheck`</Link> on the parent object, or select the schema dynamically with <Link href="/api/lazy/">`lazy`</Link>, which receives the current input as an argument.
+
+### Error messages
+
+Instead of `.typeError()` and per-validation message arguments, you pass a single string as the first argument to schemas and as the last argument to actions. See the <Link href="../quick-start/#error-messages">quick start</Link> guide for more details.
+
+```ts
+// Change this
+const Schema = yup
+  .number()
+  .typeError('Must be a number')
+  .min(10, 'Number is too small');
+
+// To this
+const Schema = v.pipe(
+  v.number('Must be a number'),
+  v.minValue(10, 'Number is too small')
+);
+```
+
+### Async validation
+
+In Yup, `.validate` is always asynchronous. Valibot is synchronous by default and provides dedicated async functions like <Link href="/api/parseAsync/">`parseAsync`</Link>, <Link href="/api/pipeAsync/">`pipeAsync`</Link> and <Link href="/api/checkAsync/">`checkAsync`</Link> for schemas that require asynchronous logic, such as database checks. See the <Link href="../async-validation/">async guide</Link> for more details.

--- a/website/src/routes/guides/(migration)/migrate-from-yup/index.mdx
+++ b/website/src/routes/guides/(migration)/migrate-from-yup/index.mdx
@@ -101,7 +101,7 @@ const DateSchema = yup.date();
 const DateSchema = v.pipe(v.string(), v.toDate());
 ```
 
-For stricter validation, we recommend adding actions like <Link href="/api/decimal/">`decimal`</Link> or <Link href="/api/isoTimestamp/">`isoTimestamp`</Link> to validate the formatting of the string before converting it.
+Keep in mind that <Link href="/api/toNumber/">`toNumber`</Link> behaves like JavaScript's `Number` function and therefore converts empty strings to `0`, and that <Link href="/api/toDate/">`toDate`</Link> accepts any string that the `Date` constructor can parse. For stricter validation, we recommend adding actions like <Link href="/api/decimal/">`decimal`</Link> or <Link href="/api/isoTimestamp/">`isoTimestamp`</Link> to validate the formatting of the string before converting it.
 
 ```ts
 const NumberSchema = v.pipe(v.string(), v.decimal(), v.toNumber());

--- a/website/src/routes/guides/menu.md
+++ b/website/src/routes/guides/menu.md
@@ -44,3 +44,9 @@
 
 - [To v0.31.0](/guides/migrate-to-v0.31.0/)
 - [From Zod](/guides/migrate-from-zod/)
+- [From TypeBox](/guides/migrate-from-typebox/)
+- [From Joi](/guides/migrate-from-joi/)
+- [From Yup](/guides/migrate-from-yup/)
+- [From class-validator](/guides/migrate-from-class-validator/)
+- [From Superstruct](/guides/migrate-from-superstruct/)
+- [From io-ts](/guides/migrate-from-io-ts/)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added new “Migration” guides for TypeBox, Joi, Yup, class-validator, Superstruct, and io-ts.
  - Each guide explains how to convert schema definitions and validation flows, map common APIs, handle optional/nullable and nested/array scenarios, use Valibot parsing/result patterns, cover unknown-key behavior, and translate async validation.
- **Navigation**
  - Updated the guides menu to include links to the new migration pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->