### PR TITLE
fix: break schemas <-> methods circular import causing flaky tests

### DIFF
--- a/library/eslint.config.js
+++ b/library/eslint.config.js
@@ -34,7 +34,7 @@ export default tseslint.config(
     },
     settings: {
       'import/parsers': {
-        '@typescript-eslint/parser': ['.ts', '.tsx'],
+        '@typescript-eslint/parser': ['.ts'],
       },
       'import/resolver': {
         typescript: {

--- a/library/eslint.config.js
+++ b/library/eslint.config.js
@@ -38,6 +38,16 @@ export default tseslint.config(
         tsconfigRootDir: import.meta.dirname,
       },
     },
+    settings: {
+      'import/parsers': {
+        '@typescript-eslint/parser': ['.ts', '.tsx'],
+      },
+      'import/resolver': {
+        typescript: {
+          project: './tsconfig.json',
+        },
+      },
+    },
     rules: {
       // Enable rules -----------------------------------------------------------
 
@@ -47,6 +57,7 @@ export default tseslint.config(
 
       // Import
       'import/extensions': ['error', 'always'], // Require file extensions
+      'import/no-cycle': 'error', // Prevent circular dependencies, which can corrupt module state under Vitest's `isolate: false` and cause flaky tests
 
       // JSDoc
       'jsdoc/tag-lines': ['error', 'any', { startLines: 1 }],

--- a/library/eslint.config.js
+++ b/library/eslint.config.js
@@ -25,16 +25,10 @@ export default tseslint.config(
   {
     files: ['src/**/*.ts'],
     extends: [importPlugin.flatConfigs.recommended],
-    languageOptions: {
-      parserOptions: {
-        project: './tsconfig.json',
-        tsconfigRootDir: import.meta.dirname,
-      },
-    },
     plugins: { jsdoc, 'redos-detector': redosDetector },
     languageOptions: {
       parserOptions: {
-        projectService: true,
+        project: './tsconfig.json',
         tsconfigRootDir: import.meta.dirname,
       },
     },

--- a/library/package.json
+++ b/library/package.json
@@ -55,6 +55,7 @@
     "@eslint/js": "^9.39.1",
     "@vitest/coverage-v8": "^4.1.8",
     "eslint": "^9.39.1",
+    "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-jsdoc": "^61.4.0",
     "eslint-plugin-redos-detector": "^3.1.1",

--- a/library/src/schemas/looseObject/looseObject.ts
+++ b/library/src/schemas/looseObject/looseObject.ts
@@ -1,4 +1,5 @@
-import { getDefault, getFallback } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
+import { getFallback } from '../../methods/getFallback/index.ts';
 import type {
   BaseSchema,
   ErrorMessage,

--- a/library/src/schemas/looseObject/looseObjectAsync.ts
+++ b/library/src/schemas/looseObject/looseObjectAsync.ts
@@ -1,4 +1,5 @@
-import { getDefault, getFallback } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
+import { getFallback } from '../../methods/getFallback/index.ts';
 import type {
   BaseSchemaAsync,
   ErrorMessage,

--- a/library/src/schemas/nullable/nullable.ts
+++ b/library/src/schemas/nullable/nullable.ts
@@ -1,4 +1,4 @@
-import { getDefault } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
 import type {
   BaseIssue,
   BaseSchema,

--- a/library/src/schemas/nullable/nullableAsync.ts
+++ b/library/src/schemas/nullable/nullableAsync.ts
@@ -1,4 +1,4 @@
-import { getDefault } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
 import type {
   BaseIssue,
   BaseSchema,

--- a/library/src/schemas/nullish/nullish.ts
+++ b/library/src/schemas/nullish/nullish.ts
@@ -1,4 +1,4 @@
-import { getDefault } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
 import type {
   BaseIssue,
   BaseSchema,

--- a/library/src/schemas/nullish/nullishAsync.ts
+++ b/library/src/schemas/nullish/nullishAsync.ts
@@ -1,4 +1,4 @@
-import { getDefault } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
 import type {
   BaseIssue,
   BaseSchema,

--- a/library/src/schemas/object/object.ts
+++ b/library/src/schemas/object/object.ts
@@ -1,4 +1,5 @@
-import { getDefault, getFallback } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
+import { getFallback } from '../../methods/getFallback/index.ts';
 import type {
   BaseSchema,
   ErrorMessage,

--- a/library/src/schemas/object/objectAsync.ts
+++ b/library/src/schemas/object/objectAsync.ts
@@ -1,4 +1,5 @@
-import { getDefault, getFallback } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
+import { getFallback } from '../../methods/getFallback/index.ts';
 import type {
   BaseSchemaAsync,
   ErrorMessage,

--- a/library/src/schemas/objectWithRest/objectWithRest.ts
+++ b/library/src/schemas/objectWithRest/objectWithRest.ts
@@ -1,4 +1,5 @@
-import { getDefault, getFallback } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
+import { getFallback } from '../../methods/getFallback/index.ts';
 import type {
   BaseIssue,
   BaseSchema,

--- a/library/src/schemas/objectWithRest/objectWithRestAsync.ts
+++ b/library/src/schemas/objectWithRest/objectWithRestAsync.ts
@@ -1,4 +1,5 @@
-import { getDefault, getFallback } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
+import { getFallback } from '../../methods/getFallback/index.ts';
 import type {
   BaseIssue,
   BaseSchema,

--- a/library/src/schemas/optional/optional.ts
+++ b/library/src/schemas/optional/optional.ts
@@ -1,4 +1,4 @@
-import { getDefault } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
 import type {
   BaseIssue,
   BaseSchema,

--- a/library/src/schemas/optional/optionalAsync.ts
+++ b/library/src/schemas/optional/optionalAsync.ts
@@ -1,4 +1,4 @@
-import { getDefault } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
 import type {
   BaseIssue,
   BaseSchema,

--- a/library/src/schemas/strictObject/strictObject.ts
+++ b/library/src/schemas/strictObject/strictObject.ts
@@ -1,4 +1,5 @@
-import { getDefault, getFallback } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
+import { getFallback } from '../../methods/getFallback/index.ts';
 import type {
   BaseSchema,
   ErrorMessage,

--- a/library/src/schemas/strictObject/strictObjectAsync.ts
+++ b/library/src/schemas/strictObject/strictObjectAsync.ts
@@ -1,4 +1,5 @@
-import { getDefault, getFallback } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
+import { getFallback } from '../../methods/getFallback/index.ts';
 import type {
   BaseSchemaAsync,
   ErrorMessage,

--- a/library/src/schemas/undefinedable/undefinedable.ts
+++ b/library/src/schemas/undefinedable/undefinedable.ts
@@ -1,4 +1,4 @@
-import { getDefault } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
 import type {
   BaseIssue,
   BaseSchema,

--- a/library/src/schemas/undefinedable/undefinedableAsync.ts
+++ b/library/src/schemas/undefinedable/undefinedableAsync.ts
@@ -1,4 +1,4 @@
-import { getDefault } from '../../methods/index.ts';
+import { getDefault } from '../../methods/getDefault/index.ts';
 import type {
   BaseIssue,
   BaseSchema,

--- a/library/src/utils/isValiError/isValiError.ts
+++ b/library/src/utils/isValiError/isValiError.ts
@@ -3,7 +3,7 @@ import type {
   BaseSchema,
   BaseSchemaAsync,
 } from '../../types/index.ts';
-import { ValiError } from '../../utils/index.ts';
+import { ValiError } from '../ValiError/index.ts';
 
 /**
  * A type guard to check if an error is a ValiError.

--- a/packages/to-json-schema/eslint.config.js
+++ b/packages/to-json-schema/eslint.config.js
@@ -25,7 +25,7 @@ export default tseslint.config(
     plugins: { jsdoc },
     settings: {
       'import/parsers': {
-        '@typescript-eslint/parser': ['.ts', '.tsx'],
+        '@typescript-eslint/parser': ['.ts'],
       },
       'import/resolver': {
         typescript: {

--- a/packages/to-json-schema/eslint.config.js
+++ b/packages/to-json-schema/eslint.config.js
@@ -24,6 +24,9 @@ export default tseslint.config(
     },
     plugins: { jsdoc },
     settings: {
+      'import/parsers': {
+        '@typescript-eslint/parser': ['.ts', '.tsx'],
+      },
       'import/resolver': {
         typescript: {
           project: './tsconfig.json',
@@ -39,6 +42,7 @@ export default tseslint.config(
 
       // Import
       'import/extensions': ['error', 'always'], // Require file extensions
+      'import/no-cycle': 'error', // Prevent circular dependencies, which can corrupt module state under Vitest's `isolate: false` and cause flaky tests
 
       // JSDoc
       'jsdoc/tag-lines': ['error', 'any', { startLines: 1 }],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,9 +84,12 @@ importers:
       eslint:
         specifier: ^9.39.1
         version: 9.39.1(jiti@2.6.1)
+      eslint-import-resolver-typescript:
+        specifier: ^4.4.4
+        version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsdoc:
         specifier: ^61.4.0
         version: 61.4.0(eslint@9.39.1(jiti@2.6.1))
@@ -155,7 +158,7 @@ importers:
         version: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-import:
         specifier: ^2.32.0
-        version: 2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
+        version: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       eslint-plugin-jsdoc:
         specifier: ^61.4.0
         version: 61.4.0(eslint@9.39.1(jiti@2.6.1))
@@ -5884,6 +5887,7 @@ packages:
 
   stream-to-promise@2.2.0:
     resolution: {integrity: sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==}
+    deprecated: Deprecated. Use node:stream/promises and node:stream/consumers instead.
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -9949,31 +9953,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.39.1(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint-module-utils@2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
-    dependencies:
-      debug: 3.2.7
-    optionalDependencies:
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 4.4.4(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.1(jiti@2.6.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -9984,7 +9979,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -9997,33 +9992,6 @@ snapshots:
       tsconfig-paths: 3.15.0
     optionalDependencies:
       '@typescript-eslint/parser': 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
-    transitivePeerDependencies:
-      - eslint-import-resolver-typescript
-      - eslint-import-resolver-webpack
-      - supports-color
-
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1)):
-    dependencies:
-      '@rtsao/scc': 1.1.0
-      array-includes: 3.1.9
-      array.prototype.findlastindex: 1.2.6
-      array.prototype.flat: 1.3.3
-      array.prototype.flatmap: 1.3.3
-      debug: 3.2.7
-      doctrine: 2.1.0
-      eslint: 9.39.1(jiti@2.6.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@4.4.4)(eslint@9.39.1(jiti@2.6.1))
-      hasown: 2.0.2
-      is-core-module: 2.16.1
-      is-glob: 4.0.3
-      minimatch: 3.1.2
-      object.fromentries: 2.0.8
-      object.groupby: 1.0.3
-      object.values: 1.2.1
-      semver: 6.3.1
-      string.prototype.trimend: 1.0.9
-      tsconfig-paths: 3.15.0
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack


### PR DESCRIPTION
# Fix flaky tests caused by a schemas <-> methods circular import

## Problem

Vitest tests failed intermittently (`"X is not a function"` errors on different
schema factories each run). Root cause: several schema modules imported
`getDefault`/`getFallback` from the aggregate `methods/index.ts` barrel, while
that barrel re-exports methods that import the `schemas/index.ts` barrel back —
a genuine circular dependency. Combined with `isolate: false` in
`vitest.config.ts` (kept for speed), module evaluation order is
non-deterministic across test files, occasionally resolving a stale/undefined
binding.

<img width="703" height="290" alt="image" src="https://github.com/user-attachments/assets/13fa9d10-b58c-4676-967d-24caf70011cc" />


## Changes

- Deep-import `getDefault`/`getFallback` in the affected schema modules instead
  of going through the `methods` barrel, breaking the cycle.
- Fix a similar self-cycle in `utils/isValiError` (imported its own domain
  barrel instead of the sibling module directly).
- Add `import/no-cycle` (ESLint) in both `library` and
  `packages/to-json-schema`, with the `eslint-import-resolver-typescript`
  resolver and `import/parsers` settings required for the rule to actually
  detect cycles across `.ts` files — verified empirically that without these
  settings the rule silently reports nothing.

## Verification

- `pnpm lint` clean in both packages.
- Full Vitest suite run 10+ times with no flakiness (`isolate: false` left
  untouched).
- Confirmed `import/no-cycle` fires correctly by temporarily reintroducing a
  cycle in both packages and reverting.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Refactor**
  * Updated internal schema and utility imports to use more direct module paths.
  * No changes to public APIs or runtime behavior.

* **Chores**
  * Improved ESLint TypeScript configuration, including resolver settings and parser routing for TypeScript files.
  * Strengthened circular-dependency detection via `import/no-cycle`.
  * Added TypeScript import resolver tooling to enhance lint import resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->