### PR TITLE
feat: check for specific UUID version

### DIFF
--- a/library/src/actions/index.ts
+++ b/library/src/actions/index.ts
@@ -120,6 +120,7 @@ export * from './types.ts';
 export * from './ulid/index.ts';
 export * from './url/index.ts';
 export * from './uuid/index.ts';
+export * from './uuidVersion/index.ts';
 export * from './value/index.ts';
 export * from './values/index.ts';
 export * from './words/index.ts';

--- a/library/src/actions/uuidVersion/index.ts
+++ b/library/src/actions/uuidVersion/index.ts
@@ -1,0 +1,1 @@
+export * from './uuidVersion.ts';

--- a/library/src/actions/uuidVersion/uuidVersion.ts
+++ b/library/src/actions/uuidVersion/uuidVersion.ts
@@ -1,0 +1,98 @@
+import type {
+  BaseIssue,
+  BaseValidation,
+  ErrorMessage,
+} from '../../types/index.ts';
+import { _addIssue } from '../../utils/index.ts';
+
+/**
+ * The UUID version union type.
+ */
+export type UuidVersion = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8;
+
+/**
+ * Builds a UUID regex that checks for a specific version. The version is the
+ * high nibble of the 13th hex digit (the first character of the third group).
+ */
+function uuidVersionRegex(version: UuidVersion): RegExp {
+  return new RegExp(
+    `^[\\da-f]{8}-[\\da-f]{4}-${version}[\\da-f]{3}-[\\da-f]{4}-[\\da-f]{12}$`,
+    'iu',
+  );
+}
+
+/**
+ * UUID version issue interface.
+ */
+export interface UuidVersionIssue<TInput extends string>
+  extends BaseIssue<TInput> {
+  readonly kind: 'validation';
+  readonly type: 'uuid_version';
+  readonly expected: null;
+  readonly received: `"${string}"`;
+  readonly requirement: RegExp;
+}
+
+/**
+ * UUID version action interface.
+ */
+export interface UuidVersionAction<
+  TInput extends string,
+  TMessage extends ErrorMessage<UuidVersionIssue<TInput>> | undefined,
+> extends BaseValidation<TInput, TInput, UuidVersionIssue<TInput>> {
+  readonly type: 'uuid_version';
+  readonly reference: typeof uuidVersion;
+  readonly expects: null;
+  readonly requirement: RegExp;
+  readonly message: TMessage;
+}
+
+/**
+ * Creates a [UUID](https://en.wikipedia.org/wiki/Universally_unique_identifier)
+ * validation action that checks for a specific version.
+ *
+ * @param version The UUID version (1-8).
+ *
+ * @returns An UUID version action.
+ */
+export function uuidVersion<TInput extends string>(
+  version: UuidVersion,
+): UuidVersionAction<TInput, undefined>;
+
+/**
+ * Creates a UUID validation action that checks for a specific version.
+ *
+ * @param version The UUID version (1-8).
+ * @param message The error message.
+ *
+ * @returns An UUID version action.
+ */
+export function uuidVersion<
+  TInput extends string,
+  const TMessage extends ErrorMessage<UuidVersionIssue<TInput>> | undefined,
+>(
+  version: UuidVersion,
+  message: TMessage,
+): UuidVersionAction<TInput, TMessage>;
+
+// @__NO_SIDE_EFFECTS__
+export function uuidVersion(
+  version: UuidVersion,
+  message?: ErrorMessage<UuidVersionIssue<string>>,
+): UuidVersionAction<string, ErrorMessage<UuidVersionIssue<string>> | undefined> {
+  return {
+    kind: 'validation',
+    type: 'uuid_version',
+    reference: uuidVersion,
+    async: false,
+    expects: null,
+    requirement: uuidVersionRegex(version),
+    message,
+    '~run'(dataset, config) {
+      if (dataset.typed && !this.requirement.test(dataset.value)) {
+        _addIssue(this, 'UUID', dataset, config);
+      }
+      return dataset;
+    },
+  };
+}


### PR DESCRIPTION
Closes #1299.

Add a `uuidVersion(version, message?)` action that takes a version (1 8) and validates the string is a UUID of that version by checking the version digit (the first character of the third group). It returns a standard validation action with a version specific regex. The existing `uuid` action is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added UUID version validation for versions 1–8.
  * Invalid UUID versions now produce validation issues with optional custom messages.
  * Added public exports for the new validation functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->