### PR TITLE
feat: support for relative URLs

### DIFF
--- a/library/src/actions/index.ts
+++ b/library/src/actions/index.ts
@@ -119,6 +119,7 @@ export * from './trimStart/index.ts';
 export * from './types.ts';
 export * from './ulid/index.ts';
 export * from './url/index.ts';
+export * from './urlRelative/index.ts';
 export * from './uuid/index.ts';
 export * from './value/index.ts';
 export * from './values/index.ts';

--- a/library/src/actions/urlRelative/index.ts
+++ b/library/src/actions/urlRelative/index.ts
@@ -1,0 +1,1 @@
+export * from './urlRelative.ts';

--- a/library/src/actions/urlRelative/urlRelative.ts
+++ b/library/src/actions/urlRelative/urlRelative.ts
@@ -1,0 +1,68 @@
+import type {
+  BaseIssue,
+  BaseValidation,
+  ErrorMessage,
+} from '../../types/index.ts';
+import { _addIssue } from '../../utils/index.ts';
+
+function isRelativeUrl(value: string): boolean {
+  if (value === '') return false;
+  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return false;
+  try {
+    new URL(value, 'http://example.com');
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface UrlRelativeIssue<TInput extends string>
+  extends BaseIssue<TInput> {
+  readonly kind: 'validation';
+  readonly type: 'url_relative';
+  readonly expected: null;
+  readonly received: `"${string}"`;
+  readonly requirement: (input: string) => boolean;
+}
+
+export interface UrlRelativeAction<
+  TInput extends string,
+  TMessage extends ErrorMessage<UrlRelativeIssue<TInput>> | undefined,
+> extends BaseValidation<TInput, TInput, UrlRelativeIssue<TInput>> {
+  readonly type: 'url_relative';
+  readonly reference: typeof urlRelative;
+  readonly expects: null;
+  readonly requirement: (input: string) => boolean;
+  readonly message: TMessage;
+}
+
+export function urlRelative<TInput extends string>(): UrlRelativeAction<
+  TInput,
+  undefined
+>;
+
+export function urlRelative<
+  TInput extends string,
+  const TMessage extends ErrorMessage<UrlRelativeIssue<TInput>> | undefined,
+>(message: TMessage): UrlRelativeAction<TInput, TMessage>;
+
+// @__NO_SIDE_EFFECTS__
+export function urlRelative(
+  message?: ErrorMessage<UrlRelativeIssue<string>>,
+): UrlRelativeAction<string, ErrorMessage<UrlRelativeIssue<string>> | undefined> {
+  return {
+    kind: 'validation',
+    type: 'url_relative',
+    reference: urlRelative,
+    async: false,
+    expects: null,
+    requirement: isRelativeUrl,
+    message,
+    '~run'(dataset, config) {
+      if (dataset.typed && !this.requirement(dataset.value)) {
+        _addIssue(this, 'URL', dataset, config);
+      }
+      return dataset;
+    },
+  };
+}


### PR DESCRIPTION
Closes #1256.

Add a `urlRelative(message?)` action that accepts relative URLs (URL references without a scheme) by resolving them against a base; absolute URLs carrying a scheme (http:, mailto:, …) are rejected, the empty string is rejected, and values that throw under the URL constructor (e.g. `//` with an empty host) are rejected. The existing `url` action is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a validation action for checking whether values are relative URLs.
  * Relative URL validation supports optional custom error messages.
  * Invalid, empty, or absolute URLs now produce a clear validation issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->