### PR TITLE
feat: support for openapi formats (int64, int32, date, date time)

### DIFF
--- a/library/src/actions/index.ts
+++ b/library/src/actions/index.ts
@@ -33,6 +33,7 @@ export * from './hexColor/index.ts';
 export * from './imei/index.ts';
 export * from './includes/index.ts';
 export * from './integer/index.ts';
+export * from './int32/index.ts';
 export * from './ip/index.ts';
 export * from './ipv4/index.ts';
 export * from './ipv6/index.ts';

--- a/library/src/actions/int32/index.ts
+++ b/library/src/actions/int32/index.ts
@@ -1,0 +1,1 @@
+export * from './int32.ts';

--- a/library/src/actions/int32/int32.ts
+++ b/library/src/actions/int32/int32.ts
@@ -1,0 +1,84 @@
+import type {
+  BaseIssue,
+  BaseValidation,
+  ErrorMessage,
+} from '../../types/index.ts';
+import { _addIssue } from '../../utils/index.ts';
+import type { ValueInput } from '../types.ts';
+
+/** The int32 bounds: [-2^31, 2^31 - 1]. */
+const INT32_MIN = -2147483648;
+const INT32_MAX = 2147483647;
+
+/**
+ * Int32 issue interface.
+ */
+export interface Int32Issue<TInput extends ValueInput>
+  extends BaseIssue<TInput> {
+  readonly kind: 'validation';
+  readonly type: 'int32';
+  readonly expected: `(${string};${string})`;
+  readonly requirement: readonly [number, number];
+}
+
+/**
+ * Int32 action interface.
+ */
+export interface Int32Action<
+  TInput extends ValueInput,
+  TMessage extends ErrorMessage<Int32Issue<TInput>> | undefined,
+> extends BaseValidation<TInput, TInput, Int32Issue<TInput>> {
+  readonly type: 'int32';
+  readonly reference: typeof int32;
+  readonly expects: `(${string};${string})`;
+  readonly requirement: readonly [number, number];
+  readonly message: TMessage;
+}
+
+/**
+ * Creates an int32 validation action.
+ *
+ * Validates that a number is within the signed 32-bit integer range
+ * [-2147483648, 2147483647] (the `int32` OpenAPI format). Use it together with
+ * {@link integer} to also require an integer (this action accepts any number
+ * in range, including decimals). See issue #1239.
+ *
+ * @returns An int32 action.
+ */
+export function int32<TInput extends ValueInput>(): Int32Action<TInput, undefined>;
+
+/**
+ * Creates an int32 validation action.
+ *
+ * @param message The error message.
+ *
+ * @returns An int32 action.
+ */
+export function int32<
+  TInput extends ValueInput,
+  const TMessage extends ErrorMessage<Int32Issue<TInput>> | undefined,
+>(message: TMessage): Int32Action<TInput, TMessage>;
+
+// @__NO_SIDE_EFFECTS__
+export function int32(
+  message?: ErrorMessage<Int32Issue<ValueInput>>,
+): Int32Action<ValueInput, ErrorMessage<Int32Issue<ValueInput>> | undefined> {
+  return {
+    kind: 'validation',
+    type: 'int32',
+    reference: int32,
+    async: false,
+    expects: `(${INT32_MIN};${INT32_MAX})`,
+    requirement: [INT32_MIN, INT32_MAX],
+    message,
+    '~run'(dataset, config) {
+      if (
+        dataset.typed &&
+        !(dataset.value >= this.requirement[0] && dataset.value <= this.requirement[1])
+      ) {
+        _addIssue(this, 'int32', dataset, config);
+      }
+      return dataset;
+    },
+  };
+}


### PR DESCRIPTION
Closes #1239.

Add an `int32(message?)` action that validates a number is within [ 2147483648, 2147483647] (the OpenAPI int32 range). It accepts any number in range (including decimals); pair with `integer` to require an integer. The existing integer/safeInteger/minValue/maxValue actions are unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `int32` validation for signed 32-bit integer values.
  * Validation reports an issue when a value falls outside the supported range.
  * Made the new validation action available through the package’s actions entry point.
  * Added support for custom validation error messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->