### PR TITLE
feat: add support for base64url regex validator

### DIFF
--- a/library/src/actions/base64Url/base64Url.ts
+++ b/library/src/actions/base64Url/base64Url.ts
@@ -1,0 +1,60 @@
+import type {
+  BaseIssue,
+  BaseValidation,
+  ErrorMessage,
+} from '../../types/index.ts';
+import { _addIssue } from '../../utils/index.ts';
+
+const BASE64URL_REGEX: RegExp =
+  /^(?:[\da-z_-]{4})*(?:[\da-z_-]{2}={0,2}|[\da-z_-]{3}={0,1})?$/iu;
+
+export interface Base64UrlIssue<TInput extends string>
+  extends BaseIssue<TInput> {
+  readonly kind: 'validation';
+  readonly type: 'base64url';
+  readonly expected: null;
+  readonly received: `"${string}"`;
+  readonly requirement: RegExp;
+}
+
+export interface Base64UrlAction<
+  TInput extends string,
+  TMessage extends ErrorMessage<Base64UrlIssue<TInput>> | undefined,
+> extends BaseValidation<TInput, TInput, Base64UrlIssue<TInput>> {
+  readonly type: 'base64url';
+  readonly reference: typeof base64Url;
+  readonly expects: null;
+  readonly requirement: RegExp;
+  readonly message: TMessage;
+}
+
+export function base64Url<TInput extends string>(): Base64UrlAction<
+  TInput,
+  undefined
+>;
+
+export function base64Url<
+  TInput extends string,
+  const TMessage extends ErrorMessage<Base64UrlIssue<TInput>> | undefined,
+>(message: TMessage): Base64UrlAction<TInput, TMessage>;
+
+// @__NO_SIDE_EFFECTS__
+export function base64Url(
+  message?: ErrorMessage<Base64UrlIssue<string>>,
+): Base64UrlAction<string, ErrorMessage<Base64UrlIssue<string>> | undefined> {
+  return {
+    kind: 'validation',
+    type: 'base64url',
+    reference: base64Url,
+    async: false,
+    expects: null,
+    requirement: BASE64URL_REGEX,
+    message,
+    '~run'(dataset, config) {
+      if (dataset.typed && !this.requirement.test(dataset.value)) {
+        _addIssue(this, 'base64url', dataset, config);
+      }
+      return dataset;
+    },
+  };
+}

--- a/library/src/actions/base64Url/index.ts
+++ b/library/src/actions/base64Url/index.ts
@@ -1,0 +1,1 @@
+export * from './base64Url.ts';

--- a/library/src/actions/index.ts
+++ b/library/src/actions/index.ts
@@ -1,6 +1,7 @@
 export * from './args/index.ts';
 export * from './await/index.ts';
 export * from './base64/index.ts';
+export * from './base64Url/index.ts';
 export * from './bic/index.ts';
 export * from './brand/index.ts';
 export * from './bytes/index.ts';


### PR DESCRIPTION
Closes #947.

Add a `base64Url(message?)` action that validates the base64url alphabet with optional padding (both padded `xx==` and unpadded `xx` forms, since base64url commonly omits padding). The existing `base64` action is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Base64URL validation for checking whether values use the required encoding format.
  * Supports optional custom validation messages.
  * Exposed the validator through the public actions API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->