### PR TITLE
docs: add spread example to `entriesFromList`

### DIFF
--- a/website/src/routes/api/(utils)/entriesFromList/index.mdx
+++ b/website/src/routes/api/(utils)/entriesFromList/index.mdx
@@ -39,6 +39,14 @@ The following example show how `entriesFromList` can be used.
 const ObjectSchema = v.object(
   v.entriesFromList(['foo', 'bar', 'baz'], v.string())
 );
+
+const ObjectSchemaWithSpread = v.object({
+  name: v.string(),
+  ...v.entriesFromList(
+    ['foo', 'bar', 'baz'],
+    v.pipe(v.string(), v.digits(), v.transform(Number))
+  ),
+});
 ```
 
 ## Related


### PR DESCRIPTION
See https://x.com/i/status/2079192795328454926

## Summary

Add an example to the `entriesFromList` API docs showing its result can be spread into `object` alongside other manually defined entries, not just passed as the sole argument.

## Reasoning

Spreading `entriesFromList` inline avoids repeating the shared schema for every key, without needing an extra named variable either:

```ts
// no repetition, no extra variable
const SpreadEntriesFromList = v.object({
  name: v.string(),
  ...v.entriesFromList(
    ['foo', 'bar', 'baz'],
    v.pipe(v.string(), v.digits(), v.transform(Number))
  ),
});

// needs an extra declaration and a name for something only used once
const DigitsToNumber = v.pipe(v.string(), v.digits(), v.transform(Number));

const UseSharedSchema = v.object({
  name: v.string(),
  foo: DigitsToNumber,
  bar: DigitsToNumber,
  baz: DigitsToNumber,
});
```

## Real World Example

See https://github.com/hyunbinseo/better-surf/commit/9fd74e762514b8645f5e1aeb7716f4be0da1d711

```ts
object(
  entriesFromList(
    RESOURCE_TYPES,
    tuple([
      pipe(
        object({
          name: string(),
          ...entriesFromList(
            ['total', 'use', 'remain'],
            pipe(string(), digits(), transform(Number))
          ),
        })
      ),
    ])
  )
);
```

## Alternatives Considered

- **Two `###` subheadings** (one example per use case, like `object`'s "Merge several objects" pattern) — dropped in favor of a single compact example, since the two snippets are just variants of the same idea rather than distinct scenarios.
- **Numbered placeholder names** (`ObjectSchema1`/`ObjectSchema2`, matching the "merge several objects" convention) — replaced with `ObjectSchema`/`ObjectSchemaWithSpread` for clarity, since here both schemas are fully declared rather than referenced placeholders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the `entriesFromList` documentation with an example showing how to spread its result into an object schema.
  * Retained the existing usage example for reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->