### PR TITLE
fix(zod-to-valibot): convert the `.brand()` method

### DIFF
--- a/codemod/zod-to-valibot/__testfixtures__/brand/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/brand/input.ts
@@ -1,0 +1,4 @@
+import { z } from "zod";
+
+const Schema1 = z.string().brand("StationNumber");
+const Schema2 = z.object({key: z.string()}).brand("Config");

--- a/codemod/zod-to-valibot/__testfixtures__/brand/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/brand/output.ts
@@ -1,0 +1,4 @@
+import * as v from "valibot";
+
+const Schema1 = v.pipe(v.string(), v.brand("StationNumber"));
+const Schema2 = v.pipe(v.object({key: v.string()}), v.brand("Config"));

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -9,6 +9,7 @@ defineTests(transform, [
   'array-schema',
   'array-validation-methods',
   'bigint-validation-methods',
+  'brand',
   'coerce-bigint-schema',
   'coerce-boolean-schema',
   'coerce-date-schema',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/constants.ts
@@ -76,6 +76,7 @@ export const ZOD_VALUE_TYPE_SCHEMAS: readonly (typeof ZOD_SCHEMAS)[number][] = [
 export const ZOD_VALIDATORS = [
   'base64',
   'base64url',
+  'brand',
   'cidr',
   'cuid',
   'cuid2',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
@@ -78,6 +78,7 @@ import {
 import { ObjectModifier, ZodSchemaType } from './types';
 import {
   transformBase64,
+  transformBrand,
   transformCUID2,
   transformDateTime,
   transformDate as transformDateValidator,
@@ -260,6 +261,8 @@ function toValibotActionExp(
       return transformBase64(...args);
     case 'base64url':
       return transformUnimplemented(...args, 'base64url');
+    case 'brand':
+      return transformBrand(...args);
     case 'cidr':
       return transformUnimplemented(...args, 'cidr');
     case 'cuid':

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/brand/brand.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/brand/brand.ts
@@ -1,0 +1,11 @@
+import j from 'jscodeshift';
+
+export function transformBrand(
+  valibotIdentifier: string,
+  args: j.CallExpression['arguments']
+) {
+  return j.callExpression(
+    j.memberExpression(j.identifier(valibotIdentifier), j.identifier('brand')),
+    args
+  );
+}

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/brand/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/brand/index.ts
@@ -1,0 +1,1 @@
+export * from './brand';

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/index.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/validators/index.ts
@@ -1,4 +1,5 @@
 export * from './base64';
+export * from './brand';
 export * from './cuid2';
 export * from './date';
 export * from './datetime';


### PR DESCRIPTION
Fixes #1501

The `@valibot/zod-to-valibot` codemod did not recognize `.brand()`, so it dropped the method name and produced invalid output:

```ts
// in
z.string().brand("StationNumber")
// out (before) — not valid
v.string()("StationNumber")
```

`brand` is now registered as a validator that maps to `v.brand(name)`, so it composes into the pipe the same way the other validators do:

```ts
// out (after)
v.pipe(v.string(), v.brand("StationNumber"))
```

The change follows the existing validator pattern: a `transformBrand` in `validators/brand/`, exported from `validators/index.ts`, dispatched from the `toValibotActionExp` switch, and `brand` added to `ZOD_VALIDATORS`. The `.brand()` argument is passed straight through since it carries no message option.

A `__testfixtures__/brand` fixture is added (registered in sorted order). It fails on `main` (the transform drops the brand) and passes with the change; `vitest run` is green with 72 fixtures and no regressions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting Zod branded schemas to equivalent Valibot schemas.
  * Supports branded strings and objects, including custom brand names.

* **Tests**
  * Added coverage for branded schema transformations, including chained schema actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->