### PR TITLE
doc: add optional email example to email API page

### DIFF
--- a/website/src/routes/api/(actions)/email/index.mdx
+++ b/website/src/routes/api/(actions)/email/index.mdx
@@ -4,6 +4,7 @@ description: Creates an email validation action.
 source: /actions/email/email.ts
 contributors:
   - fabian-hiller
+  - SAY-5
 ---
 
 import { ApiList, Link, Property } from '~/components';
@@ -50,6 +51,20 @@ const EmailSchema = v.pipe(
   v.nonEmpty('Please enter your email.'),
   v.email('The email is badly formatted.'),
   v.maxLength(30, 'Your email is too long.')
+);
+```
+
+### Optional email schema
+
+Schema to validate an email that is allowed to be an empty string, for example for an optional form field.
+
+```ts
+const OptionalEmailSchema = v.optional(
+  v.union([
+    v.literal(''),
+    v.pipe(v.string(), v.email('The email is badly formatted.')),
+  ]),
+  ''
 );
 ```
 


### PR DESCRIPTION
Closes #1494. Adds a second example to the email API page showing how to accept an empty string for an optional form field, based on the snippet suggested in the issue. Message wording matches the existing example on the page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added an example showing how to validate optional email values, including empty strings and properly formatted email addresses.
  - Updated the documentation’s contributor information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->