### PR TITLE
Fix critical tar vulnerabilities via pnpm overrides

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,8 @@ settings:
 
 overrides:
   shell-quote@1: 1.8.4
+  tar@6: 7.5.21
+  tar@7: 7.5.21
 
 patchedDependencies:
   '@builder.io/qwik-city@1.19.2': 2195348d10017bf69653482d128f793158a82c1d0eeb0e3fd909db4c503493a1
@@ -3035,10 +3037,6 @@ packages:
   chownr@1.1.4:
     resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
 
-  chownr@2.0.0:
-    resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
-    engines: {node: '>=10'}
-
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
@@ -4057,10 +4055,6 @@ packages:
     resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
     engines: {node: '>=14.14'}
 
-  fs-minipass@2.1.0:
-    resolution: {integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==}
-    engines: {node: '>= 8'}
-
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
@@ -4985,21 +4979,9 @@ packages:
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
 
-  minipass@3.3.6:
-    resolution: {integrity: sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==}
-    engines: {node: '>=8'}
-
-  minipass@5.0.0:
-    resolution: {integrity: sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==}
-    engines: {node: '>=8'}
-
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
     engines: {node: '>=16 || 14 >=14.17'}
-
-  minizlib@2.1.2:
-    resolution: {integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==}
-    engines: {node: '>= 8'}
 
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
@@ -5994,15 +5976,9 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@6.2.1:
-    resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
-    engines: {node: '>=10'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
-
-  tar@7.5.2:
-    resolution: {integrity: sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg==}
+  tar@7.5.21:
+    resolution: {integrity: sha512-XdhtCvlMywwxpCW8YEq3lOXBJpUPTR2OHHcwLPO3HwsJqOHa2Ok/oJ7ruGzp+JrKoRPVCzJwAdEjqLW/vNRPHA==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   temp@0.8.4:
     resolution: {integrity: sha512-s0ZZzd0BzYv5tLSptZooSjK8oj6C+c19p7Vqta9+6NPOf7r+fxq0cJe6/oN4LTC79sy5NY8ucOJNgwsKCSbfqg==}
@@ -7640,7 +7616,7 @@ snapshots:
       node-fetch: 2.7.0
       nopt: 8.1.0
       semver: 7.7.3
-      tar: 7.5.2
+      tar: 7.5.21
     transitivePeerDependencies:
       - encoding
       - supports-color
@@ -8588,7 +8564,7 @@ snapshots:
       semver: 7.5.4
       stat-mode: 0.3.0
       stream-to-promise: 2.2.0
-      tar: 6.2.1
+      tar: 7.5.21
       tinyexec: 0.3.2
       tree-kill: 1.2.2
       uid-promise: 1.0.0
@@ -9186,8 +9162,6 @@ snapshots:
       readdirp: 4.1.2
 
   chownr@1.1.4: {}
-
-  chownr@2.0.0: {}
 
   chownr@3.0.0: {}
 
@@ -10291,10 +10265,6 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
-
-  fs-minipass@2.1.0:
-    dependencies:
-      minipass: 3.3.6
 
   fs.realpath@1.0.0: {}
 
@@ -11481,18 +11451,7 @@ snapshots:
 
   minimist@1.2.8: {}
 
-  minipass@3.3.6:
-    dependencies:
-      yallist: 4.0.0
-
-  minipass@5.0.0: {}
-
   minipass@7.1.2: {}
-
-  minizlib@2.1.2:
-    dependencies:
-      minipass: 3.3.6
-      yallist: 4.0.0
 
   minizlib@3.1.0:
     dependencies:
@@ -12672,16 +12631,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@6.2.1:
-    dependencies:
-      chownr: 2.0.0
-      fs-minipass: 2.1.0
-      minipass: 5.0.0
-      minizlib: 2.1.2
-      mkdirp: 1.0.4
-      yallist: 4.0.0
-
-  tar@7.5.2:
+  tar@7.5.21:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,9 +20,15 @@ minimumReleaseAgeExclude:
   - miniflare@4.20260616.0
   - workerd@1.20260616.1
   - wrangler@4.101.0
+  - tar@7.5.21
 overrides:
   # Security: pin vulnerable transitive deps to patched versions (CVE Lite findings).
   # Keyed by major so only the affected major line is moved to its fixed version.
   'shell-quote@1': '1.8.4'
+  # tar@6 has no patched 6.x release (all fixes landed in 7.5.19+). Its only
+  # consumer (@vercel/fun) uses tar APIs that are unchanged in v7, so both
+  # major lines are moved to the patched v7 version.
+  'tar@6': '7.5.21'
+  'tar@7': '7.5.21'
 patchedDependencies:
   '@builder.io/qwik-city@1.19.2': patches/@builder.io__qwik-city@1.19.2.patch


### PR DESCRIPTION
## Summary

The dependency scan reported two critical findings, both for the transitive `tar` package:

| Finding | Path | Status |
| --- | --- | --- |
| `tar@6.2.1` | `vercel` → `@vercel/fun` | Fixed → `7.5.21` |
| `tar@7.5.2` | `vercel` → `…` → `@mapbox/node-pre-gyp` | Fixed → `7.5.21` |

All known tar advisories (11 in OSV, including the critical decompression DoS GHSA-23hp-3jrh-7fpw) are only fixed in **tar 7.5.19+** — there is no patched 6.x release. Both major lines are therefore pinned to `tar@7.5.21` via `overrides` in `pnpm-workspace.yaml`.

## Why overrides instead of upgrading vercel

The scanner suggested upgrading `vercel` to 50.3.1, but that was verified to be insufficient:

- `vercel@50.3.1` still ships `@vercel/fun@1.2.1`, which pins `tar@6.2.1` exactly.
- Even the latest `vercel@56.5.0` ships `@vercel/fun@1.3.0`, which pins `tar@7.5.7` — still below the 7.5.19 fix threshold. No vercel release resolves tar to a patched version.
- Additionally, every vercel major ≥ 51 depends on the npm package `sandbox` (Vercel's Sandbox CLI, which reuses an old npm package name). Two 2020 advisories for the *original* `sandbox` package (GHSA-fm4j-4xhm-xpwx, GHSA-gc25-3vc5-2jf9) have an unbounded affected range, so scanners flag Vercel's unrelated 3.x code as a critical false positive with no fixed version and no way to suppress it. Their metadata (`last_known_affected_version_range: < 1.0.0`) confirms only the old package is affected. Staying on `vercel@^48.10.10` avoids introducing that permanent false positive into the Security workflow.

## Safety of the tar 6 → 7 override

`@vercel/fun` is the only consumer of the tar 6 line. Its usage is limited to `tar.extract({ strip, C })`, which is unchanged in tar 7 — confirmed by diffing `@vercel/fun` 1.2.0 (tar 6) against 1.3.0 (tar 7): every tar call site is identical.

## Verification

- `pnpm why -r tar` shows a single `tar@7.5.21` across both paths; `tar@6.2.1` and `tar@7.5.2` are gone from the lockfile.
- Rescan (CVE Lite CLI 1.27.0, same as the Security workflow) reports **0 critical** findings and exits 0 with `--fail-on critical`.
- `vercel --version` (48.10.10) runs correctly with the overridden tar.

Out of scope: the remaining high/medium/low findings (e.g. `sharp`, `undici`, `vite`) are untouched, per the request to fix criticals only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated underlying archive handling to address security vulnerabilities and improve application reliability.
  * No user-facing functionality or interface changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->