### PR TITLE
Serve Markdown version of homepage to agents

### DIFF
--- a/website/worker/index.ts
+++ b/website/worker/index.ts
@@ -24,6 +24,22 @@ export default {
       return handleMcpRequest(request, env);
     }
 
+    // Serve our llms.txt file as the Markdown version of the homepage to
+    // negotiating agents, and add a link to it to the HTML homepage
+    if (url.pathname === '/') {
+      if (prefersMarkdown(request)) {
+        const response = await serveMarkdown(env, request, '/llms.txt');
+        if (response) {
+          return response;
+        }
+      }
+      const response = await env.ASSETS.fetch(request);
+      return withHeaders(response, {
+        Link: '</llms.txt>; rel="alternate"; type="text/markdown"',
+        Vary: 'Accept',
+      });
+    }
+
     // Serve API catalog with its official media type (RFC 9727)
     if (url.pathname === '/.well-known/api-catalog') {
       const response = await env.ASSETS.fetch(

--- a/website/worker/index.ts
+++ b/website/worker/index.ts
@@ -7,9 +7,20 @@
  * https://developers.cloudflare.com/workers/static-assets/routing/worker-script/
  */
 import { DOCS_PATH_REGEX } from './docs';
-import { withHeaders } from './headers';
+import { setHeader, withHeaders } from './headers';
 import { prefersMarkdown, serveMarkdown } from './markdown';
 import { handleMcpRequest } from './mcp';
+
+// Discovery links of the homepage for AI agents (RFC 8288). The first two
+// mirror the `/` rule of our `_headers` file, which is documented to apply
+// to static asset responses but not to responses of Worker code. Setting
+// them here as well guarantees them in both cases, as duplicate values are
+// skipped when the headers are merged.
+const HOMEPAGE_LINKS = [
+  '</.well-known/api-catalog>; rel="api-catalog"',
+  '</llms.txt>; rel="service-doc"; type="text/markdown"',
+  '</llms.txt>; rel="alternate"; type="text/markdown"',
+];
 
 export interface Env {
   ASSETS: { fetch: typeof fetch };
@@ -25,19 +36,21 @@ export default {
     }
 
     // Serve our llms.txt file as the Markdown version of the homepage to
-    // negotiating agents, and add a link to it to the HTML homepage
+    // negotiating agents, and add discovery links to the HTML homepage
     if (url.pathname === '/') {
       if (prefersMarkdown(request)) {
-        const response = await serveMarkdown(env, request, '/llms.txt');
-        if (response) {
-          return response;
+        const markdownResponse = await serveMarkdown(env, request, '/llms.txt');
+        if (markdownResponse) {
+          return markdownResponse;
         }
       }
-      const response = await env.ASSETS.fetch(request);
-      return withHeaders(response, {
-        Link: '</llms.txt>; rel="alternate"; type="text/markdown"',
+      const response = withHeaders(await env.ASSETS.fetch(request), {
         Vary: 'Accept',
       });
+      for (const link of HOMEPAGE_LINKS) {
+        setHeader(response.headers, 'Link', link);
+      }
+      return response;
     }
 
     // Serve API catalog with its official media type (RFC 9727)

--- a/website/worker/index.ts
+++ b/website/worker/index.ts
@@ -36,17 +36,17 @@ export default {
     }
 
     // Serve our llms.txt file as the Markdown version of the homepage to
-    // negotiating agents, and add discovery links to the HTML homepage
+    // negotiating agents, and add discovery links to both representations
     if (url.pathname === '/') {
+      let response: Response | undefined;
       if (prefersMarkdown(request)) {
-        const markdownResponse = await serveMarkdown(env, request, '/llms.txt');
-        if (markdownResponse) {
-          return markdownResponse;
-        }
+        response = await serveMarkdown(env, request, '/llms.txt');
       }
-      const response = withHeaders(await env.ASSETS.fetch(request), {
-        Vary: 'Accept',
-      });
+      if (!response) {
+        response = withHeaders(await env.ASSETS.fetch(request), {
+          Vary: 'Accept',
+        });
+      }
       for (const link of HOMEPAGE_LINKS) {
         setHeader(response.headers, 'Link', link);
       }

--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -17,6 +17,7 @@
     // Only run the Worker for routes with special handling for AI agents and
     // exclude Qwik City's q-data.json files to serve them asset-first
     "run_worker_first": [
+      "/",
       "/mcp",
       "/mcp/",
       "/guides/*",


### PR DESCRIPTION
## What

Requests to `/` with an `Accept` header that prefers `text/markdown` now receive the content of our `llms.txt` file as the Markdown representation of the homepage. Browsers and other clients continue to receive the HTML page, which now also advertises the Markdown alternative via a `Link: </llms.txt>; rel="alternate"; type="text/markdown"` header.

## Why

Our Markdown content negotiation currently only covers documentation pages (`/guides/*` and `/api/*`). Agents that land on the homepage with a Markdown preference get the HTML shell of our Qwik app, which is not useful to them. The `llms.txt` file is the natural Markdown representation of the site's entry point: title, tagline, and a table of contents with links to all Markdown pages. This also resolves the failing "Markdown for Agents" check on isitagentready.com, which tests `/` with `Accept: text/markdown`.

## How

- `website/worker/index.ts`: new branch for `/` that reuses the existing `serveMarkdown` helper with `/llms.txt` as the target, so all negotiation behavior (`Content-Type: text/markdown`, `Content-Location`, `Vary: Accept`, `X-Markdown-Tokens`, 304 revalidation, HEAD support) is shared with the documentation pages. The HTML path adds the `Link` header and `Vary: Accept`.
- `website/wrangler.jsonc`: added `/` to `run_worker_first` so the Worker can negotiate the homepage. All other paths are unaffected.

## Verified

- `GET /` with `Accept: text/markdown` → 200, `Content-Type: text/markdown; charset=utf-8`, `Content-Location: /llms.txt`, `Vary: Accept`, `X-Markdown-Tokens`, body is the llms.txt content
- `GET /` with a browser `Accept` header → HTML with the new `Link` header and `Vary: Accept`
- `GET /` with `Accept: */*` (e.g. curl default) → HTML, as wildcard ranges intentionally do not negotiate to Markdown
- `HEAD /` with Markdown preference → headers incl. token count, empty body
- `GET /llms.txt` unchanged (direct file serving), documentation page negotiation unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced homepage handling to negotiate an alternate Markdown representation when requested.
  * Added homepage discovery links to improve service discoverability for automated clients, with response variation based on `Accept`.
* **Bug Fixes**
  * Fixed request routing so homepage (`/`) is handled by the worker before falling back to static assets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->