### PR TITLE
doc: add `"type": "http"` to `.mcp.json` example

### DIFF
--- a/website/src/routes/guides/(get-started)/coding-agents/index.mdx
+++ b/website/src/routes/guides/(get-started)/coding-agents/index.mdx
@@ -6,7 +6,6 @@ description: >-
 contributors:
   - fabian-hiller
   - flySewa
-  - lazerg
 ---
 
 # Coding agents

--- a/website/src/routes/guides/(get-started)/coding-agents/index.mdx
+++ b/website/src/routes/guides/(get-started)/coding-agents/index.mdx
@@ -6,6 +6,7 @@ description: >-
 contributors:
   - fabian-hiller
   - flySewa
+  - lazerg
 ---
 
 # Coding agents
@@ -42,6 +43,7 @@ For Cursor and other tools that use a JSON configuration file, add the following
 {
   "mcpServers": {
     "valibot": {
+      "type": "http",
       "url": "https://valibot.dev/mcp"
     }
   }


### PR DESCRIPTION
The JSON config example for the MCP server omits the transport type, while the `claude mcp add` command right above it passes `--transport http`. Claude Code needs `"type": "http"` in `.mcp.json` for the HTTP server to work, so add it to keep the two consistent.

Closes #1564.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the MCP server configuration example to specify the HTTP server type for the Valibot server.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->