### PR TITLE
chore: reschedule and add npm target

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,10 @@ updates:
       npm-deps:
         patterns:
           - "*"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: github-actions
     directory: /
     schedule:
@@ -34,4 +38,8 @@ updates:
       github-actions:
         patterns:
           - '*'
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,9 @@ updates:
       prefix: "dependabot"
     groups:
       npm-deps:
+        update-types:
+          - "patch"
+          - "minor"
         patterns:
           - "*"
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,20 +9,15 @@ updates:
       - "/codemod/*"
     schedule:
       interval: weekly
-      day: "saturday"
-      time: "09:00"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7
     commit-message:
       prefix: "dependabot"
     groups:
-      patch-updates:
-        update-types:
-          - "patch"
-      minor-updates:
-        update-types:
-          - "minor"
+      npm-deps:
+        patterns:
+          - "*"
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,8 @@ updates:
       - "/codemod/*"
     schedule:
       interval: weekly
+      day: "saturday"
+      time: "09:00"
     open-pull-requests-limit: 5
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,12 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: /
+    directories:
+      - "/"
+      - "/library"
+      - "/packages/*"
+      - "/website"
+      - "/codemod/*"
     schedule:
       interval: weekly
       day: "saturday"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,6 +39,9 @@ updates:
       prefix: "dependabot"
     groups:
       github-actions:
+        update-types:
+          - "patch"
+          - "minor"
         patterns:
           - '*'
     ignore:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,29 @@
 version: 2
 updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+      day: "saturday"
+      time: "09:00"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 7
+    commit-message:
+      prefix: "dependabot"
+    groups:
+      patch-updates:
+        update-types:
+          - "patch"
+      minor-updates:
+        update-types:
+          - "minor"
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: monthly
+      interval: weekly
+      day: "saturday"
+      time: "09:00"
     cooldown:
       default-days: 7
     commit-message:


### PR DESCRIPTION
rescheduled depenadbot interval monthly to weekly.
It is best to update library versions frequently.
I’ll be reviewing them on my own initiative every week.

I have also included npm packages in the scope for Dependabot.
I will be checking these on a weekly basis as well.

Regarding major version updates, automatic updates are too risky, so we have decided to verify them ourselves.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Chores**
  * Automated dependency updates are now scheduled weekly for both npm packages and GitHub Actions (with GitHub Actions set to a Saturday time).
  * npm updates are scoped to key project directories, grouped to limit open pull requests, and use a longer default cooldown with a `dependabot` commit prefix.
  * Major semver updates for general dependencies (`*`) are ignored for safer automated rollouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->