### PR TITLE
Replace Discord invite link with new link

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -91,4 +91,4 @@ I am completely free and licensed under the [MIT license](https://github.com/ope
 [jsr-image]: https://jsr.io/badges/@valibot/valibot?style=flat-square
 [jsr-url]: https://jsr.io/@valibot/valibot
 [discord-image]: https://img.shields.io/discord/1252985447273992222?label=Discord&style=flat-square
-[discord-url]: https://discord.gg/tkMjQACf2P
+[discord-url]: https://discord.gg/w5mRTETqzv

--- a/website/src/components/DiscordIconLink.tsx
+++ b/website/src/components/DiscordIconLink.tsx
@@ -9,7 +9,7 @@ export const DiscordIconLink = component$(() => (
   <SystemIcon
     label="Join our Discord server"
     type="link"
-    href="https://discord.gg/tkMjQACf2P"
+    href="https://discord.gg/w5mRTETqzv"
     target="_blank"
   >
     <DiscordIcon class="h-full" />

--- a/website/src/routes/(legal)/contact/index.mdx
+++ b/website/src/routes/(legal)/contact/index.mdx
@@ -11,7 +11,7 @@ Valibot is an open source project led by Fabian Hiller and developed publicly on
 
 ## General inquiries
 
-For general inquiries, such as bug reports and feature requests, please [create an issue](https://github.com/open-circle/valibot/issues/new) on GitHub. If you have any questions or need help with Valibot, you can [ask the community](https://discord.gg/tkMjQACf2P) on our Discord server.
+For general inquiries, such as bug reports and feature requests, please [create an issue](https://github.com/open-circle/valibot/issues/new) on GitHub. If you have any questions or need help with Valibot, you can [ask the community](https://discord.gg/w5mRTETqzv) on our Discord server.
 
 ## Security issues
 

--- a/website/src/routes/(legal)/privacy/index.mdx
+++ b/website/src/routes/(legal)/privacy/index.mdx
@@ -49,7 +49,7 @@ Please note that data transmitted via the internet (e.g. via email communication
 
 ### Notice concerning the party responsible for this website
 
-The party responsible for processing data on this website is the Valibot project and its contributors. You can contact us via [GitHub](https://github.com/open-circle/valibot) or [Discord](https://discord.gg/tkMjQACf2P).
+The party responsible for processing data on this website is the Valibot project and its contributors. You can contact us via [GitHub](https://github.com/open-circle/valibot) or [Discord](https://discord.gg/w5mRTETqzv).
 
 The responsible party is the natural or legal person who alone or jointly with others decides on the purposes and means of processing personal data (names, email addresses, etc.).
 

--- a/website/src/routes/blog/(posts)/valibot-v1-the-1-kb-schema-library/index.mdx
+++ b/website/src/routes/blog/(posts)/valibot-v1-the-1-kb-schema-library/index.mdx
@@ -207,6 +207,6 @@ Below you will find our most influential contributors as well as our current and
 
 ## What's next on our list?
 
-With Valibot v1, you can rest assured that the library is stable and ready for production. But we are not done yet, we are basically just getting started. On our list are things like a VS Code extension to improve the developer experience, a Zod-to-Valibot codemod to increase adoption, and an OpenAPI package to improve compatibility with other libraries. If you would like to lead or contribute to these efforts, please [contact us on Discord](https://discord.gg/tkMjQACf2P)!
+With Valibot v1, you can rest assured that the library is stable and ready for production. But we are not done yet, we are basically just getting started. On our list are things like a VS Code extension to improve the developer experience, a Zod-to-Valibot codemod to increase adoption, and an OpenAPI package to improve compatibility with other libraries. If you would like to lead or contribute to these efforts, please [contact us on Discord](https://discord.gg/w5mRTETqzv)!
 
 > Just in case this is the first time you hear about Valibot and you have never tried it before, feel free to take a look at our <Link href='/guides/quick-start/' target='_blank'>quick start guide</Link> and experiment with the library in our <Link href='/playground/' target='_blank'>online playground</Link>.

--- a/website/src/routes/blog/(posts)/valibot-v1.2-release-notes/index.mdx
+++ b/website/src/routes/blog/(posts)/valibot-v1.2-release-notes/index.mdx
@@ -129,6 +129,6 @@ We're excited to welcome [LambdaTest](https://lambdatest.com/) as a new partner!
 
 ## What's next?
 
-We're creating more guides to help you get the most out of Valibot. Got a specific use case or pattern you'd like us to cover? Let us know on [Discord](https://discord.gg/Jwf9vjvReZ) or open a discussion on [GitHub](https://github.com/open-circle/valibot/discussions).
+We're creating more guides to help you get the most out of Valibot. Got a specific use case or pattern you'd like us to cover? Let us know on [Discord](https://discord.gg/w5mRTETqzv) or open a discussion on [GitHub](https://github.com/open-circle/valibot/discussions).
 
 New to Valibot? [Get started](/start). Coming from Zod? [Migration guide](/migration). [Full changelog](https://github.com/open-circle/valibot/releases/tag/v1.2.0).

--- a/website/src/routes/blog/(posts)/valibot-v1.3-release-notes/index.mdx
+++ b/website/src/routes/blog/(posts)/valibot-v1.3-release-notes/index.mdx
@@ -137,6 +137,6 @@ Finally, the type system now handles deeply readonly default and fallback values
 
 ## What's next?
 
-We will continue to improve integrations, and refine the developer experience around common validation workflows. If there is a validator, transformation, or guide you would like to see next, let us know on [Discord](https://discord.gg/Jwf9vjvReZ) or open a discussion on [GitHub](https://github.com/open-circle/valibot/discussions).
+We will continue to improve integrations, and refine the developer experience around common validation workflows. If there is a validator, transformation, or guide you would like to see next, let us know on [Discord](https://discord.gg/w5mRTETqzv) or open a discussion on [GitHub](https://github.com/open-circle/valibot/discussions).
 
 New to Valibot? Check our [quick start guide](/guides/quick-start/). Coming from Zod? Check our [migration guide](/guides/migrate-from-zod/).

--- a/website/src/routes/blog/(posts)/valibot-v1.4-release-notes/index.mdx
+++ b/website/src/routes/blog/(posts)/valibot-v1.4-release-notes/index.mdx
@@ -72,6 +72,6 @@ The <Link href="/api/intersect/">`intersect`</Link> schema no longer mutates inp
 
 ## What's next?
 
-We will continue to focus on performance, broader runtime compatibility, and refining the developer experience around common validation workflows. If there is a validator, transformation, or guide you would like to see next, let us know on [Discord](https://discord.gg/Jwf9vjvReZ) or open a discussion on [GitHub](https://github.com/open-circle/valibot/discussions).
+We will continue to focus on performance, broader runtime compatibility, and refining the developer experience around common validation workflows. If there is a validator, transformation, or guide you would like to see next, let us know on [Discord](https://discord.gg/w5mRTETqzv) or open a discussion on [GitHub](https://github.com/open-circle/valibot/discussions).
 
 New to Valibot? Check our [quick start guide](/guides/quick-start/). Coming from Zod? Check our [migration guide](/guides/migrate-from-zod/).


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated community invitation links across the README, website navigation, contact and privacy pages, and historical release articles.
  * Ensured all listed Discord links direct visitors to the current invitation destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->