### PR TITLE
Fix loading of shared code in playground of website

### DIFF
--- a/website/src/components/CodeEditor.tsx
+++ b/website/src/components/CodeEditor.tsx
@@ -111,6 +111,14 @@ export const CodeEditor = component$<CodeEditorProps>(
       });
     });
 
+    // Update value of model on change
+    useTask$(({ track }) => {
+      track(value);
+      if (isBrowser && model.value && value.value !== model.value.getValue()) {
+        model.value.setValue(value.value);
+      }
+    });
+
     // Update theme on change
     useTask$(async ({ track }) => {
       track(editorTheme);

--- a/website/src/routes/playground/index.tsx
+++ b/website/src/routes/playground/index.tsx
@@ -76,7 +76,8 @@ export default component$(() => {
     const code = new URLSearchParams(window.location.search).get('code');
     if (code) {
       initialCode.value =
-        lz.decompressFromEncodedURIComponent(code) || editorCode;
+        lz.decompressFromEncodedURIComponent(code) ||
+        '// Failed to load the shared code. The link may be corrupted or incomplete.';
     }
   });
 

--- a/website/src/routes/playground/index.tsx
+++ b/website/src/routes/playground/index.tsx
@@ -5,7 +5,6 @@ import {
   type QRL,
   type Signal,
   sync$,
-  useComputed$,
   useSignal,
   useVisibleTask$,
 } from '@builder.io/qwik';
@@ -51,9 +50,8 @@ export const head: DocumentHead = {
 };
 
 export default component$(() => {
-  // Use navigate, location and side bar toggle
+  // Use navigate and side bar toggle
   const navigate = useNavigate();
-  const location = useLocation();
   const toggle = useSideBarToggle();
 
   // Use editor and side bar elements signals
@@ -69,10 +67,16 @@ export default component$(() => {
   const logsElement = useSignal<HTMLOListElement>();
   const lastLogElement = useSignal<Element | null>();
 
-  // Computed initial code of editor
-  const initialCode = useComputed$(() => {
-    const code = location.url.searchParams.get('code');
-    return code ? lz.decompressFromEncodedURIComponent(code) : editorCode;
+  // Use initial code of editor signal
+  const initialCode = useSignal(editorCode);
+
+  // Get initial code of editor from search params
+  // eslint-disable-next-line qwik/no-use-visible-task
+  useVisibleTask$(() => {
+    const code = new URLSearchParams(window.location.search).get('code');
+    if (code) {
+      initialCode.value = lz.decompressFromEncodedURIComponent(code);
+    }
   });
 
   /**

--- a/website/src/routes/playground/index.tsx
+++ b/website/src/routes/playground/index.tsx
@@ -75,7 +75,8 @@ export default component$(() => {
   useVisibleTask$(() => {
     const code = new URLSearchParams(window.location.search).get('code');
     if (code) {
-      initialCode.value = lz.decompressFromEncodedURIComponent(code);
+      initialCode.value =
+        lz.decompressFromEncodedURIComponent(code) || editorCode;
     }
   });
 


### PR DESCRIPTION
Playground URLs with a `code` param opened the default editor content instead of the shared code. The website is a fully static export, so the computed initial code runs at build time, where no `code` param exists, and the serialized value was always the default. This reads the param from `window.location` in a visible task, so the editor picks up the shared code on the client.

I checked it against a static build: `/playground/?code=PTAEAsFMBtoe1AdzgJ2gEyA` now opens with `// hello world`, and `/playground/` still opens with the default example.

Fixes #1574


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playground code loading from the browser URL’s `code` parameter.
  * Ensured the editor initializes and updates with shared code more reliably.
  * Added a visible error message when shared code cannot be loaded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->