### PR TITLE
Replace `CLAUDE.md` symlink with `@AGENTS.md` import

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,1 @@
-AGENTS.md
+@AGENTS.md


### PR DESCRIPTION
Git for Windows does not create symlinks unless the clone sets `core.symlinks=true` and the user has Administrator rights or Developer Mode enabled. Without that, `CLAUDE.md` lands as a regular file whose entire content is the string `AGENTS.md`, so Claude Code loads that as the project instructions instead of the real ones.

The Claude Code memory docs recommend the `@AGENTS.md` import for this case, so this replaces the symlink with a one-line file. Nothing changes on macOS and Linux, where both forms resolve to the same content.

Fixes #1576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project guidance to remove an outdated reference.
  * No changes were made to application functionality or the end-user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->