### PR TITLE
chore: add npm keywords to valibot package

### DIFF
--- a/library/package.json
+++ b/library/package.json
@@ -17,7 +17,11 @@
     "parsing",
     "bundle-size",
     "type-safe",
-    "runtime"
+    "runtime",
+    "validator",
+    "schema-validation",
+    "type-inference",
+    "standard-schema"
   ],
   "type": "module",
   "main": "./dist/index.mjs",


### PR DESCRIPTION
Adds `validator`, `schema-validation`, `type-inference` and `standard-schema` to the npm keywords so the package ranks for these searches. Takes effect with the next publish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added package keywords highlighting validation, schema support, type inference, and standard schema compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->