### PR TITLE
docs: add new libraries to ecosystem page

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -41,6 +41,8 @@ This page is for you if you are looking for frameworks or libraries that support
 
 ## Frameworks
 
+- [Better Auth](https://www.better-auth.com/): The most comprehensive authentication framework for TypeScript
+- [Elysia](https://elysiajs.com/): Ergonomic framework for humans with end-to-end type safety
 - [EviKit](https://codeberg.org/nykula/evikit): Preact SSR framework using Valibot to let you define node:sqlite ORM schemas and validate OpenAPI (Swagger) inputs and outputs
 - [NestJS](https://docs.nestjs.com): A progressive Node.js framework for building efficient, reliable and scalable server-side applications
 - [Qwik](https://qwik.dev): A web framework which helps you build instantly-interactive web apps at any scale without effort.
@@ -60,6 +62,10 @@ This page is for you if you are looking for frameworks or libraries that support
 ## AI libraries
 
 - [AI SDK](https://sdk.vercel.ai/): Build AI-powered applications with React, Svelte, Vue, and Solid
+- [Flue](https://flueframework.com/): Open agent framework that uses Valibot for tool inputs and structured output
+- [LangChain](https://js.langchain.com/): Framework for developing applications powered by large language models
+- [Mastra](https://mastra.ai/): TypeScript agent framework to build AI applications and features
+- [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk): The official TypeScript SDK for the Model Context Protocol
 
 ## Form libraries
 


### PR DESCRIPTION
Adds Better Auth and Elysia to the frameworks section and Flue, LangChain, Mastra and the MCP TypeScript SDK to the AI libraries section. All of them accept Valibot schemas, either natively or via Standard Schema.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Better Auth and Elysia to the listed frameworks.
  * Added Flue, LangChain, Mastra, and MCP TypeScript SDK to the AI libraries list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->