### PR TITLE
docs: improve title and description of comparison guide

### DIFF
--- a/website/src/routes/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/guides/(get-started)/comparison/index.mdx
@@ -1,8 +1,8 @@
 ---
-title: Comparison
+title: Comparison with Zod and others
 description: >-
-  Even though Valibot's API resembles other solutions at first glance, the
-  implementation and structure of the source code is very different.
+  How Valibot compares to Zod, Yup and other schema libraries in bundle size,
+  performance and API design.
 contributors:
   - fabian-hiller
   - nikolailehbrink
@@ -11,7 +11,7 @@ contributors:
 
 # Comparison
 
-Even though Valibot's API resembles other solutions at first glance, the implementation and structure of the source code is very different. In the following, we would like to highlight the differences that can be beneficial for both you and your users.
+Even though Valibot's API resembles other solutions like Zod and Yup at first glance, the implementation and structure of the source code is very different. In the following, we would like to highlight the differences that can be beneficial for both you and your users.
 
 ## Modular design
 

--- a/website/src/routes/guides/(get-started)/comparison/index.mdx
+++ b/website/src/routes/guides/(get-started)/comparison/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: Comparison with Zod and others
 description: >-
-  How Valibot compares to Zod, Yup and other schema libraries in bundle size,
+  How Valibot compares to other schema libraries like Zod in bundle size,
   performance and API design.
 contributors:
   - fabian-hiller
@@ -9,9 +9,9 @@ contributors:
   - Neon-20
 ---
 
-# Comparison
+# Comparison with Zod and others
 
-Even though Valibot's API resembles other solutions like Zod and Yup at first glance, the implementation and structure of the source code is very different. In the following, we would like to highlight the differences that can be beneficial for both you and your users.
+Even though Valibot's API resembles other solutions like Zod and Yup at first glance, the implementation and structure of the source code are very different. In the following, we would like to highlight the differences that can be beneficial for both you and your users.
 
 ## Modular design
 


### PR DESCRIPTION
Updates the document title and meta description of the comparison guide to include the library names users actually search for. Third-party posts currently outrank this page for these queries. The bundle size numbers were re-checked and left unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the comparison guide metadata and heading to identify it as a comparison with Zod and other schema libraries.
  * Expanded the introduction to reference Zod and Yup.
  * Added comparison criteria covering bundle size, performance, and API design.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->