### PR TITLE
docs: add shorn to ecosystem utilities

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -31,6 +31,7 @@ contributors:
   - haihv
   - nykula
   - yamcodes
+  - ChiChuRita
 ---
 
 # Ecosystem
@@ -117,6 +118,7 @@ This page is for you if you are looking for frameworks or libraries that support
 - [@valibot/i18n](https://github.com/open-circle/valibot/tree/main/packages/i18n): The official i18n translations for Valibot
 - [ArkEnv](https://github.com/yamcodes/arkenv): Environment variable validation from editor to runtime, for Next.js, Nuxt, Node.js, Vite, Bun, and more
 - [fastify-type-provider-valibot](https://github.com/qlaffont/fastify-type-provider-valibot): Fastify Type Provider with Valibot
+- [shorn](https://shorn.dev): Compact binary serialization that uses your Valibot schema as the wire format, with no IDL or code generation
 - [valibot-env](https://y-hiraoka.github.io/valibot-env): Environment variables validator with Valibot
 - [valibotx](https://github.com/IlyaSemenov/valibotx): A collection of extensions and shortcuts to core Valibot functions
 - [valiload](https://github.com/JuerGenie/valiload): A simple and lightweight library for overloading functions in TypeScript


### PR DESCRIPTION
Adds shorn to the Utilities category, alphabetically between `fastify-type-provider-valibot` and `valibot-env`, and adds myself to the page contributors.

shorn uses a Valibot schema as a binary wire format. An object with a string and a non-negative integer field is 35 bytes of minified JSON and 8 bytes through shorn. Field names and type tags stay off the wire because the schema already carries them, so there is no IDL and nothing to generate.

For validation it reads Standard Schema, and for structure it reads Standard JSON Schema, so Valibot works by passing `toStandardJsonSchema(schema)` from `@valibot/to-json-schema` alongside the schema. There is no Valibot-specific code path in the library. Golden test vectors pin the exact bytes across Valibot, Zod and ArkType, so equivalent schemas in any of the three encode identically.

Docs: https://shorn.dev
Repo: https://github.com/ChiChuRita/shorn
npm: `@chichurita/shorn`

Worth flagging: shorn is at 0.1.0 and describes itself as experimental. The wire format is not frozen until 1.0. If the page is meant for stable libraries only, I am happy to close this and open it again later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `shorn` utility to the Ecosystem list.
  * Updated the page contributor information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->