### PR TITLE
Fix version comment of upload-sarif action pin

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
           verbose: 'true'
           sarif: 'true'
       - name: Upload SARIF to GitHub
-        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4
+        uses: github/codeql-action/upload-sarif@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         if: always()
         with:
           sarif_file: ${{ github.workspace }}


### PR DESCRIPTION
The zizmor workflow audit currently fails on every PR (e.g. #1597) with a `ref-version-mismatch` finding in `security.yml`:

> action's hash pin has mismatched or missing version comment

The `github/codeql-action/upload-sarif` step is pinned to commit `5595ccaf`, but the comment says `# v4` — a moving tag that has since advanced to a different commit. The pinned hash corresponds exactly to the `v4.37.6` release tag (verified via the GitHub API), so this PR updates the comment to `# v4.37.6`, matching the exact-version comment style used by every other pin in the repo.

Verified locally with zizmor v1.29.0 (the same version as CI): no findings remain.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the security workflow’s SARIF upload action documentation to specify version `v4.37.6`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->