### PR TITLE
Configure Worker observability

### DIFF
--- a/website/wrangler.jsonc
+++ b/website/wrangler.jsonc
@@ -9,6 +9,21 @@
   "compatibility_date": "2026-06-16",
   // Worker that serves Markdown to AI agents via content negotiation
   "main": "./worker/index.ts",
+  "observability": {
+    "enabled": false,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true,
+    },
+    "traces": {
+      "enabled": true,
+      "persist": true,
+      "head_sampling_rate": 1,
+    },
+  },
   "assets": {
     "directory": "./dist",
     "binding": "ASSETS",


### PR DESCRIPTION
## Summary

- add the dashboard-generated observability settings to the Wrangler configuration
- enable and persist invocation logs with full sampling
- enable and persist traces with full sampling

## Why

This keeps the Wrangler configuration as the source of truth so the observability settings remain consistent across deployments instead of existing only in the Cloudflare dashboard.

## Validation

- `pnpm exec prettier --check website/wrangler.jsonc`
- `pnpm exec wrangler deploy --dry-run`
- `git diff --check`