### PR TITLE
fix(to-json-schema): derive lazy reference IDs from the conversion context

### DIFF
--- a/packages/to-json-schema/CHANGELOG.md
+++ b/packages/to-json-schema/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to the library will be documented in this file.
 - Add passthrough of other `metadata` action properties to support custom annotations and standard keywords like `format`, which take precedence over generated properties (pull request #1591)
 - Fix `examples` property type of `JsonSchema` to always be an array (pull request #1607)
 - Fix JSON compatibility validation of `literal` schemas to reject `NaN` and infinite numbers by default (pull request #1573)
+- Fix generation of reference IDs for `lazy` schemas to depend on the conversion context instead of a module scoped counter (pull request #1604)
 
 ## v1.7.1 (June 08, 2026)
 

--- a/packages/to-json-schema/CHANGELOG.md
+++ b/packages/to-json-schema/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the library will be documented in this file.
 - Fix JSON compatibility validation of `literal` schemas to reject `NaN` and infinite numbers by default (pull request #1573)
 - Fix `minValue`, `maxValue`, `gtValue` and `ltValue` actions to skip numeric constraints on unsupported types in `warn` and `ignore` error modes (pull request #1595)
 - Fix generation of reference IDs for `lazy` schemas to produce consistent output and avoid collisions with existing definitions (pull request #1604)
+- Change `ConversionContext.referenceMap` type from `Map` to its `ReferenceMap` subclass (pull request #1604)
 
 ## v1.7.1 (June 08, 2026)
 

--- a/packages/to-json-schema/src/converters/convertSchema/convertSchema.test.ts
+++ b/packages/to-json-schema/src/converters/convertSchema/convertSchema.test.ts
@@ -1449,6 +1449,42 @@ describe('convertSchema', () => {
       ).toStrictEqual({ $ref: '#/$defs/1' });
     });
 
+    test('should skip taken keys for every generated reference ID', () => {
+      const takenSchema = v.number();
+      const wrappedSchemas = [v.string(), v.boolean(), v.null()];
+      const context = createContext({
+        definitions: { '1': { type: 'number' } },
+        referenceMap: new Map().set(takenSchema, '1'),
+      });
+
+      // Hint: Reference IDs are allocated one after the other within a single
+      // context, so every allocation must skip the taken `'1'` key, not just
+      // the first one.
+      for (const [index, wrappedSchema] of wrappedSchemas.entries()) {
+        expect(
+          convertSchema(
+            {},
+            v.lazy(() => wrappedSchema),
+            undefined,
+            context
+          )
+        ).toStrictEqual({ $ref: `#/$defs/${['0', '2', '3'][index]}` });
+      }
+
+      expect(context.definitions).toStrictEqual({
+        '0': { type: 'string' },
+        '1': { type: 'number' },
+        '2': { type: 'boolean' },
+        '3': { type: 'null' },
+      });
+      expect([...context.referenceMap.values()]).toStrictEqual([
+        '1',
+        '0',
+        '2',
+        '3',
+      ]);
+    });
+
     test('should convert recursive lazy schema with static getter', () => {
       // Returns a static reference that never changes
       const lazyGetter = () => nodeSchema;

--- a/packages/to-json-schema/src/converters/convertSchema/convertSchema.test.ts
+++ b/packages/to-json-schema/src/converters/convertSchema/convertSchema.test.ts
@@ -1,5 +1,6 @@
 import * as v from 'valibot';
 import { describe, expect, test, vi } from 'vitest';
+import { ReferenceMap } from '../../utils/index.ts';
 import { createContext } from '../../vitest/index.ts';
 import { convertSchema } from './convertSchema.ts';
 
@@ -16,7 +17,7 @@ describe('convertSchema', () => {
           undefined,
           createContext({
             definitions: { foo: { type: 'string' } },
-            referenceMap: new Map().set(schema, 'foo'),
+            referenceMap: new ReferenceMap().set(schema, 'foo'),
           })
         )
       ).toStrictEqual({
@@ -33,7 +34,7 @@ describe('convertSchema', () => {
           undefined,
           createContext({
             definitions: { 'Shared/User~': { type: 'string' } },
-            referenceMap: new Map().set(schema, 'Shared/User~'),
+            referenceMap: new ReferenceMap().set(schema, 'Shared/User~'),
           })
         )
       ).toStrictEqual({
@@ -50,7 +51,7 @@ describe('convertSchema', () => {
           undefined,
           createContext({
             definitions: { foo: { type: 'string' } },
-            referenceMap: new Map().set(stringSchema, 'foo'),
+            referenceMap: new ReferenceMap().set(stringSchema, 'foo'),
           }),
           true
         )
@@ -68,7 +69,7 @@ describe('convertSchema', () => {
           undefined,
           createContext({
             definitions: { foo: { type: 'string' } },
-            referenceMap: new Map().set(stringSchema, 'foo'),
+            referenceMap: new ReferenceMap().set(stringSchema, 'foo'),
           }),
           false
         )
@@ -87,10 +88,9 @@ describe('convertSchema', () => {
           items: { $ref: '#/$defs/string' },
         },
       } as const;
-      const referenceMap = new Map<v.GenericSchema, string>([
-        [stringSchema, 'string'],
-        [arraySchema, 'array'],
-      ]);
+      const referenceMap = new ReferenceMap()
+        .set(stringSchema, 'string')
+        .set(arraySchema, 'array');
       expect(
         convertSchema(
           {},
@@ -122,7 +122,7 @@ describe('convertSchema', () => {
           },
           createContext({
             definitions: { foo: { type: 'string' }, bar: { type: 'number' } },
-            referenceMap: new Map().set(foo, 'foo').set(bar, 'bar'),
+            referenceMap: new ReferenceMap().set(foo, 'foo').set(bar, 'bar'),
           })
         )
       ).toStrictEqual({
@@ -176,7 +176,7 @@ describe('convertSchema', () => {
           undefined,
           createContext({
             definitions: { foo: { type: 'string' } },
-            referenceMap: new Map().set(schema, 'foo'),
+            referenceMap: new ReferenceMap().set(schema, 'foo'),
           })
         )
       ).toStrictEqual({
@@ -1394,7 +1394,7 @@ describe('convertSchema', () => {
       ).toStrictEqual({ $ref: '#/$defs/0' });
       expect(context).toStrictEqual({
         definitions: { '0': { type: 'string' } },
-        referenceMap: new Map().set(stringSchema, '0'),
+        referenceMap: new ReferenceMap().set(stringSchema, '0'),
         getterMap: new Map().set(lazyGetter, stringSchema),
       });
     });
@@ -1404,7 +1404,7 @@ describe('convertSchema', () => {
       const lazyGetter = () => stringSchema;
       const context = createContext({
         definitions: { testSchema: { type: 'string' } },
-        referenceMap: new Map().set(stringSchema, 'stringSchema'),
+        referenceMap: new ReferenceMap().set(stringSchema, 'stringSchema'),
       });
       expect(
         convertSchema(
@@ -1416,7 +1416,7 @@ describe('convertSchema', () => {
       ).toStrictEqual({ $ref: '#/$defs/stringSchema' });
       expect(context).toStrictEqual({
         definitions: { testSchema: { type: 'string' } },
-        referenceMap: new Map().set(stringSchema, 'stringSchema'),
+        referenceMap: new ReferenceMap().set(stringSchema, 'stringSchema'),
         getterMap: new Map().set(lazyGetter, stringSchema),
       });
     });
@@ -1428,7 +1428,7 @@ describe('convertSchema', () => {
       const createTakenContext = () =>
         createContext({
           definitions: { '0': { type: 'number' } },
-          referenceMap: new Map().set(numberSchema, '0'),
+          referenceMap: new ReferenceMap().set(numberSchema, '0'),
         });
 
       const firstContext = createTakenContext();
@@ -1437,7 +1437,9 @@ describe('convertSchema', () => {
       ).toStrictEqual({ $ref: '#/$defs/1' });
       expect(firstContext).toStrictEqual({
         definitions: { '0': { type: 'number' }, '1': { type: 'string' } },
-        referenceMap: new Map().set(numberSchema, '0').set(stringSchema, '1'),
+        referenceMap: new ReferenceMap()
+          .set(numberSchema, '0')
+          .set(stringSchema, '1'),
         getterMap: new Map().set(lazyGetter, stringSchema),
       });
 
@@ -1454,7 +1456,7 @@ describe('convertSchema', () => {
       const wrappedSchemas = [v.string(), v.boolean(), v.null()];
       const context = createContext({
         definitions: { '1': { type: 'number' } },
-        referenceMap: new Map().set(takenSchema, '1'),
+        referenceMap: new ReferenceMap().set(takenSchema, '1'),
       });
 
       // Hint: Reference IDs are allocated one after the other within a single
@@ -1513,7 +1515,7 @@ describe('convertSchema', () => {
             required: [],
           },
         },
-        referenceMap: new Map().set(nodeSchema, '0'),
+        referenceMap: new ReferenceMap().set(nodeSchema, '0'),
         getterMap: new Map().set(lazyGetter, nodeSchema),
       });
     });
@@ -1551,7 +1553,7 @@ describe('convertSchema', () => {
             ],
           },
         },
-        referenceMap: new Map().set(expect.any(Object), '0'),
+        referenceMap: new ReferenceMap().set(expect.any(Object), '0'),
         getterMap: new Map().set(lazyGetter, expect.any(Object)),
       });
     });

--- a/packages/to-json-schema/src/converters/convertSchema/convertSchema.test.ts
+++ b/packages/to-json-schema/src/converters/convertSchema/convertSchema.test.ts
@@ -1421,6 +1421,34 @@ describe('convertSchema', () => {
       });
     });
 
+    test('should not reuse taken key for generated reference ID', () => {
+      const numberSchema = v.number();
+      const stringSchema = v.string();
+      const lazyGetter = () => stringSchema;
+      const createTakenContext = () =>
+        createContext({
+          definitions: { '0': { type: 'number' } },
+          referenceMap: new Map().set(numberSchema, '0'),
+        });
+
+      const firstContext = createTakenContext();
+      expect(
+        convertSchema({}, v.lazy(lazyGetter), undefined, firstContext)
+      ).toStrictEqual({ $ref: '#/$defs/1' });
+      expect(firstContext).toStrictEqual({
+        definitions: { '0': { type: 'number' }, '1': { type: 'string' } },
+        referenceMap: new Map().set(numberSchema, '0').set(stringSchema, '1'),
+        getterMap: new Map().set(lazyGetter, stringSchema),
+      });
+
+      // Hint: The second conversion must return the same reference ID as the
+      // first one, as the ID only depends on the conversion context.
+      const secondContext = createTakenContext();
+      expect(
+        convertSchema({}, v.lazy(lazyGetter), undefined, secondContext)
+      ).toStrictEqual({ $ref: '#/$defs/1' });
+    });
+
     test('should convert recursive lazy schema with static getter', () => {
       // Returns a static reference that never changes
       const lazyGetter = () => nodeSchema;
@@ -1438,18 +1466,18 @@ describe('convertSchema', () => {
         )
       ).toStrictEqual({
         type: 'object',
-        properties: { node: { $ref: '#/$defs/1' } },
+        properties: { node: { $ref: '#/$defs/0' } },
         required: [],
       });
       expect(context).toStrictEqual({
         definitions: {
-          '1': {
+          '0': {
             type: 'object',
-            properties: { node: { $ref: '#/$defs/1' } },
+            properties: { node: { $ref: '#/$defs/0' } },
             required: [],
           },
         },
-        referenceMap: new Map().set(nodeSchema, '1'),
+        referenceMap: new Map().set(nodeSchema, '0'),
         getterMap: new Map().set(lazyGetter, nodeSchema),
       });
     });
@@ -1471,23 +1499,23 @@ describe('convertSchema', () => {
         )
       ).toStrictEqual({
         type: 'object',
-        properties: { node: { $ref: '#/$defs/2' } },
+        properties: { node: { $ref: '#/$defs/0' } },
         required: ['node'],
       });
       expect(context).toStrictEqual({
         definitions: {
-          '2': {
+          '0': {
             anyOf: [
               {
                 type: 'object',
-                properties: { node: { $ref: '#/$defs/2' } },
+                properties: { node: { $ref: '#/$defs/0' } },
                 required: ['node'],
               },
               { type: 'null' },
             ],
           },
         },
-        referenceMap: new Map().set(expect.any(Object), '2'),
+        referenceMap: new Map().set(expect.any(Object), '0'),
         getterMap: new Map().set(lazyGetter, expect.any(Object)),
       });
     });

--- a/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
+++ b/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
@@ -135,6 +135,23 @@ function getDefinitionRef(referenceId: string): string {
 }
 
 /**
+ * The reference ID allocation state of a single conversion context.
+ */
+interface ReferenceIdState {
+  /**
+   * The reference IDs that are already taken.
+   */
+  readonly usedIds: Set<string>;
+  /**
+   * The next reference ID candidate.
+   */
+  count: number;
+}
+
+// Create reference ID state cache
+const referenceIdStates = new WeakMap<ConversionContext, ReferenceIdState>();
+
+/**
  * Creates a reference ID that is not yet used by the conversion context.
  *
  * @param context The conversion context.
@@ -142,15 +159,38 @@ function getDefinitionRef(referenceId: string): string {
  * @returns The unused reference ID.
  */
 function createReferenceId(context: ConversionContext): string {
-  const usedIds = new Set([
-    ...Object.keys(context.definitions),
-    ...context.referenceMap.values(),
-  ]);
-  let count = 0;
-  while (usedIds.has(`${count}`)) {
-    count++;
+  // Get or initialize reference ID state of conversion context
+  // Hint: Both entry points register every provided definition in the
+  // reference map before any conversion starts, so this initial scan sees all
+  // externally provided reference IDs.
+  let state = referenceIdStates.get(context);
+  if (!state) {
+    state = {
+      usedIds: new Set([
+        ...Object.keys(context.definitions),
+        ...context.referenceMap.values(),
+      ]),
+      count: 0,
+    };
+    referenceIdStates.set(context, state);
   }
-  return `${count}`;
+
+  // Search for next unused reference ID
+  // Hint: Every returned ID is marked as used, so generated IDs strictly
+  // increase and the search can resume where the previous one stopped instead
+  // of rescanning the entire context on every call.
+  while (
+    state.usedIds.has(`${state.count}`) ||
+    `${state.count}` in context.definitions
+  ) {
+    state.count++;
+  }
+
+  // Mark reference ID as used and return it
+  const referenceId = `${state.count}`;
+  state.usedIds.add(referenceId);
+  state.count++;
+  return referenceId;
 }
 
 /**

--- a/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
+++ b/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
@@ -135,73 +135,6 @@ function getDefinitionRef(referenceId: string): string {
 }
 
 /**
- * The reference ID allocation state of a single conversion context.
- */
-interface ReferenceIdState {
-  /**
-   * The reference IDs that are already taken.
-   */
-  readonly usedIds: Set<string>;
-  /**
-   * The next reference ID candidate.
-   */
-  count: number;
-}
-
-// Create reference ID state cache
-const referenceIdStates = new WeakMap<ConversionContext, ReferenceIdState>();
-
-/**
- * Creates a reference ID that is not yet used by the conversion context.
- *
- * @param context The conversion context.
- * @param config The conversion configuration.
- *
- * @returns The unused reference ID.
- */
-function createReferenceId(
-  context: ConversionContext,
-  config: ConversionConfig | undefined
-): string {
-  // Get or initialize reference ID state of conversion context
-  // Hint: Both entry points reserve every provided definition key before
-  // conversion, including aliases that share the same schema.
-  let state = referenceIdStates.get(context);
-  if (!state) {
-    state = {
-      usedIds: new Set([
-        ...Object.keys(context.definitions),
-        ...context.referenceMap.values(),
-      ]),
-      count: 0,
-    };
-    referenceIdStates.set(context, state);
-  } else if (config?.overrideSchema || config?.overrideRef) {
-    // Overrides can reserve or replace reference IDs between allocations.
-    // Without overrides, every new ID is already tracked by this allocator.
-    for (const referenceId of context.referenceMap.values()) {
-      state.usedIds.add(referenceId);
-    }
-  }
-
-  // Search for next unused reference ID
-  // Hint: Every returned ID is marked as used, so generated IDs strictly
-  // increase and the search can resume where the previous one stopped.
-  while (
-    state.usedIds.has(`${state.count}`) ||
-    `${state.count}` in context.definitions
-  ) {
-    state.count++;
-  }
-
-  // Mark reference ID as used and return it
-  const referenceId = `${state.count}`;
-  state.usedIds.add(referenceId);
-  state.count++;
-  return referenceId;
-}
-
-/**
  * Converts any supported Valibot schema to the JSON Schema format.
  *
  * @param jsonSchema The JSON Schema object.
@@ -690,7 +623,7 @@ export function convertSchema(
 
       // Add wrapped Valibot schema to reference map and definitions, if necessary
       if (!referenceId) {
-        referenceId = createReferenceId(context, config);
+        referenceId = context.referenceMap.createId(context.definitions);
         context.referenceMap.set(wrappedValibotSchema, referenceId);
         context.definitions[referenceId] = convertSchema(
           {},

--- a/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
+++ b/packages/to-json-schema/src/converters/convertSchema/convertSchema.ts
@@ -134,8 +134,24 @@ function getDefinitionRef(referenceId: string): string {
   return `#/$defs/${referenceId.replaceAll('~', '~0').replaceAll('/', '~1')}`;
 }
 
-// Create global reference count
-let refCount = 0;
+/**
+ * Creates a reference ID that is not yet used by the conversion context.
+ *
+ * @param context The conversion context.
+ *
+ * @returns The unused reference ID.
+ */
+function createReferenceId(context: ConversionContext): string {
+  const usedIds = new Set([
+    ...Object.keys(context.definitions),
+    ...context.referenceMap.values(),
+  ]);
+  let count = 0;
+  while (usedIds.has(`${count}`)) {
+    count++;
+  }
+  return `${count}`;
+}
 
 /**
  * Converts any supported Valibot schema to the JSON Schema format.
@@ -626,7 +642,7 @@ export function convertSchema(
 
       // Add wrapped Valibot schema to reference map and definitions, if necessary
       if (!referenceId) {
-        referenceId = `${refCount++}`;
+        referenceId = createReferenceId(context);
         context.referenceMap.set(wrappedValibotSchema, referenceId);
         context.definitions[referenceId] = convertSchema(
           {},

--- a/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.test.ts
+++ b/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.test.ts
@@ -185,6 +185,101 @@ describe('toJsonSchema', () => {
       });
     });
 
+    test('for overrides with only previously converted definitions', () => {
+      const stringSchema = v.string();
+      const numberSchema = v.number();
+      expect(
+        toJsonSchema(stringSchema, {
+          definitions: { stringSchema, numberSchema },
+          overrideSchema(context) {
+            if (context.valibotSchema === stringSchema) {
+              expect(context.definitions).toStrictEqual({});
+            } else if (context.valibotSchema === numberSchema) {
+              expect(context.definitions).toStrictEqual({
+                stringSchema: { type: 'string' },
+              });
+            }
+            return null;
+          },
+        })
+      ).toStrictEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        $ref: '#/$defs/stringSchema',
+        $defs: {
+          stringSchema: { type: 'string' },
+          numberSchema: { type: 'number' },
+        },
+      });
+    });
+
+    test('for lazy schemas with definition added by override', () => {
+      const stringSchema = v.string();
+      const numberSchema = v.number();
+      expect(
+        toJsonSchema(
+          v.object({
+            foo: v.lazy(() => stringSchema),
+            bar: v.lazy(() => numberSchema),
+          }),
+          {
+            overrideSchema(context) {
+              if (context.valibotSchema === stringSchema) {
+                context.definitions['1'] = { type: 'boolean' };
+              }
+              return null;
+            },
+          }
+        )
+      ).toStrictEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          foo: { $ref: '#/$defs/0' },
+          bar: { $ref: '#/$defs/2' },
+        },
+        required: ['foo', 'bar'],
+        $defs: {
+          '0': { type: 'string' },
+          '1': { type: 'boolean' },
+          '2': { type: 'number' },
+        },
+      });
+    });
+
+    test('for lazy schemas with conversion inside override', () => {
+      const stringSchema = v.string();
+      const numberSchema = v.number();
+      expect(
+        toJsonSchema(
+          v.object({
+            foo: v.lazy(() => stringSchema),
+            bar: v.lazy(() => numberSchema),
+          }),
+          {
+            overrideSchema(context) {
+              if (context.valibotSchema === stringSchema) {
+                // A nested conversion must not reset the outer reference counter.
+                toJsonSchema(v.boolean());
+              }
+              return null;
+            },
+          }
+        )
+      ).toStrictEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          foo: { $ref: '#/$defs/0' },
+          bar: { $ref: '#/$defs/1' },
+        },
+        required: ['foo', 'bar'],
+        $defs: {
+          '0': { type: 'string' },
+          '1': { type: 'number' },
+        },
+      });
+    });
+
     test('for lazy schemas with reference added by override', () => {
       const stringSchema = v.string();
       const numberSchema = v.number();
@@ -218,6 +313,48 @@ describe('toJsonSchema', () => {
         },
         required: ['foo', 'bar', 'baz'],
         $defs: {
+          '0': { type: 'string' },
+          '1': { type: 'boolean' },
+          '2': { type: 'number' },
+        },
+      });
+    });
+
+    test('for lazy schemas with reference replaced by override', () => {
+      const stringSchema = v.string();
+      const numberSchema = v.number();
+      const booleanSchema = v.boolean();
+      expect(
+        toJsonSchema(
+          v.object({
+            foo: v.lazy(() => stringSchema),
+            bar: v.lazy(() => numberSchema),
+            baz: booleanSchema,
+          }),
+          {
+            definitions: { booleanSchema },
+            overrideRef(context) {
+              if (context.valibotSchema === stringSchema) {
+                // Replacing a reference does not change the map's size.
+                context.referenceMap.set(booleanSchema, '1');
+              } else if (context.valibotSchema === numberSchema) {
+                context.definitions['1'] = { type: 'boolean' };
+              }
+              return undefined;
+            },
+          }
+        )
+      ).toStrictEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: {
+          foo: { $ref: '#/$defs/0' },
+          bar: { $ref: '#/$defs/2' },
+          baz: { $ref: '#/$defs/1' },
+        },
+        required: ['foo', 'bar', 'baz'],
+        $defs: {
+          booleanSchema: { type: 'boolean' },
           '0': { type: 'string' },
           '1': { type: 'boolean' },
           '2': { type: 'number' },

--- a/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.test.ts
+++ b/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.test.ts
@@ -140,6 +140,27 @@ describe('toJsonSchema', () => {
       });
     });
 
+    test('for recursive schema without definitions on repeated calls', () => {
+      const nodeSchema: v.GenericSchema = v.object({
+        child: v.optional(v.lazy(() => nodeSchema)),
+      });
+      const expectedJsonSchema = {
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'object',
+        properties: { child: { $ref: '#/$defs/0' } },
+        required: [],
+        $defs: {
+          '0': {
+            type: 'object',
+            properties: { child: { $ref: '#/$defs/0' } },
+            required: [],
+          },
+        },
+      };
+      expect(toJsonSchema(nodeSchema)).toStrictEqual(expectedJsonSchema);
+      expect(toJsonSchema(nodeSchema)).toStrictEqual(expectedJsonSchema);
+    });
+
     test('for definitions with JSON Pointer special characters', () => {
       const sharedSchema = v.object({ name: v.string() });
       expect(

--- a/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.ts
+++ b/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.ts
@@ -6,6 +6,7 @@ import type {
   ConversionContext,
   JsonSchema,
 } from '../../types/index.ts';
+import { ReferenceMap } from '../../utils/index.ts';
 
 /**
  * Converts a Valibot schema to the JSON Schema format.
@@ -22,7 +23,7 @@ export function toJsonSchema(
   // Initialize JSON Schema context
   const context: ConversionContext = {
     definitions: {},
-    referenceMap: new Map(),
+    referenceMap: new ReferenceMap(),
     getterMap: new Map(),
   };
 
@@ -33,8 +34,6 @@ export function toJsonSchema(
   if (definitions) {
     for (const key in definitions) {
       context.referenceMap.set(definitions[key], key);
-      // Reserve every key because the same schema can have multiple names.
-      context.definitions[key] = {};
     }
     for (const key in definitions) {
       context.definitions[key] = convertSchema(

--- a/packages/to-json-schema/src/functions/toJsonSchemaDefs/toJsonSchemaDefs.test.ts
+++ b/packages/to-json-schema/src/functions/toJsonSchemaDefs/toJsonSchemaDefs.test.ts
@@ -102,6 +102,31 @@ describe('toJsonSchemaDefs', () => {
       });
     });
 
+    test('for overrides with only previously converted definitions', () => {
+      const stringSchema = v.string();
+      const numberSchema = v.number();
+      expect(
+        toJsonSchemaDefs(
+          { stringSchema, numberSchema },
+          {
+            overrideSchema(context) {
+              if (context.valibotSchema === stringSchema) {
+                expect(context.definitions).toStrictEqual({});
+              } else if (context.valibotSchema === numberSchema) {
+                expect(context.definitions).toStrictEqual({
+                  stringSchema: { type: 'string' },
+                });
+              }
+              return null;
+            },
+          }
+        )
+      ).toStrictEqual({
+        stringSchema: { type: 'string' },
+        numberSchema: { type: 'number' },
+      });
+    });
+
     test('for recursive schema', () => {
       const ul = v.object({
         type: v.literal('ul'),

--- a/packages/to-json-schema/src/functions/toJsonSchemaDefs/toJsonSchemaDefs.ts
+++ b/packages/to-json-schema/src/functions/toJsonSchemaDefs/toJsonSchemaDefs.ts
@@ -5,6 +5,7 @@ import type {
   ConversionContext,
   JsonSchema,
 } from '../../types/index.ts';
+import { ReferenceMap } from '../../utils/index.ts';
 
 /**
  * Converts Valibot schema definitions to JSON Schema definitions.
@@ -26,15 +27,13 @@ export function toJsonSchemaDefs<
   // Initialize JSON Schema context
   const context: ConversionContext = {
     definitions: {},
-    referenceMap: new Map(),
+    referenceMap: new ReferenceMap(),
     getterMap: new Map(),
   };
 
   // Add provided definitions to context, if necessary
   for (const key in definitions) {
     context.referenceMap.set(definitions[key], key);
-    // Reserve every key because the same schema can have multiple names.
-    context.definitions[key] = {};
   }
   for (const key in definitions) {
     context.definitions[key] = convertSchema(

--- a/packages/to-json-schema/src/types/config.ts
+++ b/packages/to-json-schema/src/types/config.ts
@@ -1,4 +1,5 @@
 import type * as v from 'valibot';
+import type { ReferenceMap } from '../utils/index.ts';
 import type { JsonSchema } from './schema.ts';
 
 /**
@@ -13,10 +14,7 @@ export interface ConversionContext {
    * The JSON Schema reference map that is used to look up the reference ID
    * for a given Valibot schema.
    */
-  readonly referenceMap: Map<
-    v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
-    string
-  >;
+  readonly referenceMap: ReferenceMap;
   /**
    * The lazy schema getter map that is used internally to ensure that
    * recursive lazy schemas are unwrapped only once.

--- a/packages/to-json-schema/src/utils/ReferenceMap.ts
+++ b/packages/to-json-schema/src/utils/ReferenceMap.ts
@@ -1,0 +1,62 @@
+import type * as v from 'valibot';
+import type { JsonSchema } from '../types/index.ts';
+
+/**
+ * Schema reference map with collision-free reference ID allocation.
+ */
+export class ReferenceMap extends Map<
+  v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+  string
+> {
+  /**
+   * The used reference IDs.
+   */
+  private readonly usedIds: Set<string>;
+
+  /**
+   * The next reference ID candidate.
+   */
+  private count = 0;
+
+  /**
+   * Creates an empty schema reference map.
+   */
+  constructor() {
+    // Entries would call set before usedIds is initialized.
+    super();
+    this.usedIds = new Set();
+  }
+
+  /**
+   * Adds a schema reference and reserves its ID.
+   *
+   * @param schema The Valibot schema.
+   * @param referenceId The reference ID.
+   *
+   * @returns The reference map.
+   */
+  override set(
+    schema: v.BaseSchema<unknown, unknown, v.BaseIssue<unknown>>,
+    referenceId: string
+  ): this {
+    this.usedIds.add(referenceId);
+    return super.set(schema, referenceId);
+  }
+
+  /**
+   * Creates a reference ID that is not yet used.
+   *
+   * @param definitions The JSON Schema definitions.
+   *
+   * @returns The unused reference ID.
+   */
+  createId(definitions: Record<string, JsonSchema>): string {
+    while (
+      this.usedIds.has(`${this.count}`) ||
+      `${this.count}` in definitions
+    ) {
+      this.count++;
+    }
+    return `${this.count++}`;
+  }
+}

--- a/packages/to-json-schema/src/utils/index.ts
+++ b/packages/to-json-schema/src/utils/index.ts
@@ -3,3 +3,4 @@ export * from './escapeRegExp.ts';
 export * from './handleError.ts';
 export * from './isJsonConstValue.ts';
 export * from './isJsonEnumValues.ts';
+export * from './ReferenceMap.ts';

--- a/packages/to-json-schema/src/vitest/createContext.ts
+++ b/packages/to-json-schema/src/vitest/createContext.ts
@@ -1,4 +1,5 @@
 import type { ConversionContext } from '../types/index.ts';
+import { ReferenceMap } from '../utils/index.ts';
 
 /**
  * Creates a new conversion context.
@@ -12,7 +13,7 @@ export function createContext(
 ): ConversionContext {
   return {
     definitions: initial?.definitions ?? {},
-    referenceMap: initial?.referenceMap ?? new Map(),
+    referenceMap: initial?.referenceMap ?? new ReferenceMap(),
     getterMap: new Map(),
   };
 }


### PR DESCRIPTION
Generated reference IDs for `lazy` schemas currently depend on previous conversions in the process and can overwrite user-provided definitions. For example, a generated string definition can reuse `'0'` even when that name already belongs to a number schema, changing what existing references validate.

This change gives each conversion a `ReferenceMap` with its own counter and reserved-ID set. Its `set()` method records every ID, including definition aliases and references added or replaced by override hooks. `createId()` skips reserved IDs and existing definition keys without rescanning the map. Repeated conversions produce stable references, and nested conversions have independent state.

Provided names are reserved before conversion without inserting unfinished definition placeholders into the context visible to callbacks. The implementation uses TypeScript private fields and an explicit no-argument constructor for the existing ES2020 build target.

`ConversionContext.referenceMap` is now typed as `ReferenceMap`, which retains the Map API. Callback consumers continue to use the same map operations; externally constructed contexts containing a plain Map need a type adjustment. The changelog records this type change and the reference-ID fix.

Validation:

- 248 package tests pass; `ReferenceMap` has 100% statement, branch, and function coverage.
- Regression tests cover repeated and nested conversions, numeric collisions, definition aliases, reference additions/replacements by override hooks, definitions added without map entries, and callback visibility of converted definitions.
- TypeScript, Deno, ESLint, Prettier, and package build pass.
- Additional built-output checks cover all three schema targets, and all four JavaScript outputs parse as ES2020.
- Local Node 24 benchmark: 3,200 lazy references with override hooks take about 1 ms per conversion, compared with about 38 ms for the previous PR revision that rescanned the map.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed generated reference IDs for lazy and recursive schemas to avoid collisions with existing definitions.
  - Ensured repeated conversions produce consistent JSON Schema output and references.
  - Corrected generated `$defs` and `$ref` values for recursive schemas without user-provided definitions.
  - Improved reference generation and deduplication when schemas are reused.
  - Rejected non-finite numeric literals such as `NaN` and infinite values.
  - Numeric constraints now skip unsupported types in warning and ignore modes.

- **Tests**
  - Added coverage for stable references, collision avoidance, schema deduplication, repeated conversions, and non-finite literal validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->