### PR TITLE
fix(to-json-schema): do not emit numeric keywords for non-number types

### DIFF
--- a/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
+++ b/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
@@ -476,6 +476,17 @@ describe('convertAction', () => {
     ).toThrowError(error);
   });
 
+  test('should warn error for gt value action with invalid type', () => {
+    expect(
+      convertAction({ type: 'string' }, v.gtValue<v.ValueInput, 3>(3), {
+        errorMode: 'warn',
+      })
+    ).toStrictEqual({ type: 'string' });
+    expect(console.warn).toHaveBeenLastCalledWith(
+      'The "gt_value" action is not supported on type "string".'
+    );
+  });
+
   test('should convert includes action', () => {
     expect(
       convertAction(
@@ -723,6 +734,17 @@ describe('convertAction', () => {
     ).toThrowError(error);
   });
 
+  test('should warn error for lt value action with invalid type', () => {
+    expect(
+      convertAction({ type: 'string' }, v.ltValue<v.ValueInput, 10>(10), {
+        errorMode: 'warn',
+      })
+    ).toStrictEqual({ type: 'string' });
+    expect(console.warn).toHaveBeenLastCalledWith(
+      'The "lt_value" action is not supported on type "string".'
+    );
+  });
+
   test('should convert max entries action', () => {
     expect(
       convertAction(
@@ -844,9 +866,7 @@ describe('convertAction', () => {
   test('should warn error for max value action with invalid type', () => {
     expect(
       convertAction({}, v.maxValue<v.ValueInput, 3>(3), { errorMode: 'warn' })
-    ).toStrictEqual({
-      maximum: 3,
-    });
+    ).toStrictEqual({});
     expect(console.warn).toHaveBeenLastCalledWith(
       'The "max_value" action is not supported on type "undefined".'
     );
@@ -854,7 +874,7 @@ describe('convertAction', () => {
       convertAction({ type: 'string' }, v.maxValue<v.ValueInput, 3>(3), {
         errorMode: 'warn',
       })
-    ).toStrictEqual({ type: 'string', maximum: 3 });
+    ).toStrictEqual({ type: 'string' });
     expect(console.warn).toHaveBeenLastCalledWith(
       'The "max_value" action is not supported on type "string".'
     );
@@ -1066,9 +1086,7 @@ describe('convertAction', () => {
   test('should warn error for min value action with invalid type', () => {
     expect(
       convertAction({}, v.minValue<v.ValueInput, 3>(3), { errorMode: 'warn' })
-    ).toStrictEqual({
-      minimum: 3,
-    });
+    ).toStrictEqual({});
     expect(console.warn).toHaveBeenLastCalledWith(
       'The "min_value" action is not supported on type "undefined".'
     );
@@ -1076,7 +1094,7 @@ describe('convertAction', () => {
       convertAction({ type: 'string' }, v.minValue<v.ValueInput, 3>(3), {
         errorMode: 'warn',
       })
-    ).toStrictEqual({ type: 'string', minimum: 3 });
+    ).toStrictEqual({ type: 'string' });
     expect(console.warn).toHaveBeenLastCalledWith(
       'The "min_value" action is not supported on type "string".'
     );

--- a/packages/to-json-schema/src/converters/convertAction/convertAction.ts
+++ b/packages/to-json-schema/src/converters/convertAction/convertAction.ts
@@ -298,6 +298,7 @@ export function convertAction(
           errors,
           `The "gt_value" action is not supported on type "${jsonSchema.type}".`
         );
+        break;
       }
       if (config?.target === 'openapi-3.0') {
         errors = addError(
@@ -388,6 +389,7 @@ export function convertAction(
           errors,
           `The "lt_value" action is not supported on type "${jsonSchema.type}".`
         );
+        break;
       }
       if (config?.target === 'openapi-3.0') {
         errors = addError(
@@ -426,6 +428,7 @@ export function convertAction(
           errors,
           `The "max_value" action is not supported on type "${jsonSchema.type}".`
         );
+        break;
       }
       jsonSchema.maximum = valibotAction.requirement as number;
       break;
@@ -493,6 +496,7 @@ export function convertAction(
           errors,
           `The "min_value" action is not supported on type "${jsonSchema.type}".`
         );
+        break;
       }
       jsonSchema.minimum = valibotAction.requirement as number;
       break;

--- a/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.test.ts
+++ b/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.test.ts
@@ -230,6 +230,17 @@ describe('toJsonSchema', () => {
         type: 'string',
       });
     });
+
+    test('for invalid min value action on a string', () => {
+      expect(
+        toJsonSchema(v.pipe(v.string(), v.minValue('m')), {
+          errorMode: 'ignore',
+        })
+      ).toStrictEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'string',
+      });
+    });
   });
 
   describe('should handle target config', () => {


### PR DESCRIPTION
Fixes #1594.

## Problem

With `errorMode: 'ignore'` or `'warn'`, the `min_value` / `max_value` / `gt_value` / `lt_value` cases in `convertAction` record the "not supported on type" error but then still assign the numeric keyword unconditionally. The result is a JSON Schema that violates the meta-schema, because `minimum`/`maximum`/`exclusiveMinimum`/`exclusiveMaximum` must be numbers:

```js
toJsonSchema(v.pipe(v.string(), v.minValue('m')), { errorMode: 'ignore' });
// before: { type: 'string', minimum: 'm', $schema: '…' }  ← Ajv: "data/minimum must be number"
// after:  { type: 'string', $schema: '…' }
```

`v.pipe(v.string(), v.minValue('m'))` is a valid Valibot schema (lexicographic string comparison), and the README's contract for the non-throw modes is that unsupported actions are dropped — which is what `v.pipe(v.string(), v.creditCard())` already does.

## Change

A single `break;` after `addError` in each of the four cases, so the keyword is only written when the type is `number`/`integer`. `errorMode: 'throw'` is unaffected (it throws before reaching the assignment either way), as is every valid numeric conversion.

For `gt_value`/`lt_value` this also means the type error now short-circuits before the OpenAPI 3.0 check, so a `gtValue` on a string under `openapi-3.0` reports the type problem rather than additionally reporting the OpenAPI one — the first error is the actionable one, and in `throw` mode only the first was ever surfaced anyway.

## Tests

- The two existing `warn` tests for `max_value`/`min_value` asserted the buggy output (`{ type: 'string', minimum: 3 }`); updated to the schema-valid result.
- Added `warn`-mode coverage for `gt_value` and `lt_value` on a string, which had no such test.
- Added an end-to-end `errorMode: 'ignore'` case in `toJsonSchema.test.ts` mirroring the issue's repro.

`pnpm test` in `packages/to-json-schema`: **230 passed**, no type errors. `eslint` and `tsc --noEmit` clean (`deno check` not run — no local deno binary). Formatted with Prettier.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented numeric validation constraints from being added to schemas with unsupported types.
  * In warning mode, invalid numeric constraints now return the schema unchanged and log a warning.
  * In ignore mode, invalid numeric constraints are silently skipped without causing errors.

* **Tests**
  * Added coverage for invalid numeric actions applied to string schemas across warning and ignore modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->