### PR TITLE
fix(to-json-schema): type examples as an array, not a bare JSON value

### DIFF
--- a/packages/to-json-schema/CHANGELOG.md
+++ b/packages/to-json-schema/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the library will be documented in this file.
 
 - Add support for `ksuid` action (pull request #1370)
 - Add passthrough of other `metadata` action properties to support custom annotations and standard keywords like `format`, which take precedence over generated properties (pull request #1591)
+- Fix `examples` property type of `JsonSchema` to always be an array (pull request #1607)
 
 ## v1.7.1 (June 08, 2026)
 

--- a/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
+++ b/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
@@ -421,6 +421,17 @@ describe('convertAction', () => {
     });
   });
 
+  test('examples should type as an array, not a bare JSON Schema value', () => {
+    const jsonSchema = convertAction({}, v.examples(['foo', 'bar']), undefined);
+    // `.map` only exists on the array member of `JsonSchemaType`. If
+    // `examples` regresses to allowing a non-array value, this fails to
+    // compile under `vitest --typecheck`, not just at runtime.
+    expect(jsonSchema.examples?.map((example) => example)).toStrictEqual([
+      'foo',
+      'bar',
+    ]);
+  });
+
   test('should merge examples from multiple actions', () => {
     const jsonSchema = {};
     convertAction(jsonSchema, v.examples(['foo']), undefined);

--- a/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
+++ b/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
@@ -425,7 +425,7 @@ describe('convertAction', () => {
     const jsonSchema = convertAction({}, v.examples(['foo', 'bar']), undefined);
     // `.map` only exists on the array member of `JsonSchemaType`. If
     // `examples` regresses to allowing a non-array value, this fails to
-    // compile under `vitest --typecheck`, not just at runtime.
+    // compile under `tsc --noEmit`, not just at runtime.
     expect(jsonSchema.examples?.map((example) => example)).toStrictEqual([
       'foo',
       'bar',

--- a/packages/to-json-schema/src/types/schema.ts
+++ b/packages/to-json-schema/src/types/schema.ts
@@ -76,7 +76,7 @@ export interface JsonSchema {
   default?: JsonSchemaType | undefined;
   readOnly?: boolean | undefined;
   writeOnly?: boolean | undefined;
-  examples?: JsonSchemaType | undefined;
+  examples?: JsonSchemaType[] | undefined;
 }
 
 /**


### PR DESCRIPTION
Fixes #1581.

## What

`JsonSchema.examples` was typed as `JsonSchemaType | undefined`. JSON Schema requires `examples` to always be an array; this let it type as a bare string/number/object/etc, which no `examples` value the converter ever actually produces.

## Why

`convertAction.ts` already treats it as an array at runtime — both the `examples` action case and the `metadata` case do `Array.isArray(jsonSchema.examples)` checks before spreading into it — and the `examples` action case wraps its assignments in `@ts-expect-error` because the old type didn't actually permit what the code was doing.

## How

Changed `examples?: JsonSchemaType | undefined` to `examples?: JsonSchemaType[] | undefined` in `packages/to-json-schema/src/types/schema.ts`.

The two existing `@ts-expect-error` comments in the `examples` action case still suppress a real error after this change (the array elements come from a schema's own arbitrary input type, not something narrowed to `JsonSchemaType`), so I left them in place rather than remove them — I checked with `tsc --noEmit` that removing either one does reintroduce a real error, so they're not stale.

## Test plan

- [x] Unit tests added/updated

Added a test that calls `.map()` on the returned `examples` without a cast. `.map` only exists on the array member of `JsonSchemaType`, so this only compiles under `tsc --noEmit` if `examples` is actually typed as an array. Confirmed it: fails to compile with the old type restored (`Property 'map' does not exist on type 'string | number | boolean | JsonSchemaObject | JsonSchemaArray'`), compiles clean with the fix.

(Note: I initially tried to verify this via `vitest --typecheck`, which reported no errors either way — that runner doesn't appear to check arbitrary type errors in plain `.test.ts` files here, only `tsc --noEmit` does, which is also what `pnpm lint` runs. Verified against the tool that actually gates CI.)

Ran the full `to-json-schema` suite: 228 passed, no regressions. `eslint` and `prettier --check` clean on both changed files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * JSON Schema definitions now represent the `examples` property consistently as an array, allowing multiple example values.

* **Bug Fixes**
  * Improved generated schema typing so `examples` supports standard array operations, such as mapping, without being treated as a single value.

* **Documentation**
  * Updated the changelog to document the consistent array format for `examples`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->