### PR TITLE
docs(website): add standard-tool to the AI libraries ecosystem list

### DIFF
--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -67,6 +67,7 @@ This page is for you if you are looking for frameworks or libraries that support
 - [LangChain](https://js.langchain.com/): Framework for developing applications powered by large language models
 - [Mastra](https://mastra.ai/): TypeScript agent framework to build AI applications and features
 - [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk): The official TypeScript SDK for the Model Context Protocol
+- [standard-tool](https://github.com/finom/standard-tool): One interface for an LLM tool, with Valibot schemas for its input and output
 
 ## Form libraries
 

--- a/website/src/routes/guides/(get-started)/ecosystem/index.mdx
+++ b/website/src/routes/guides/(get-started)/ecosystem/index.mdx
@@ -67,7 +67,7 @@ This page is for you if you are looking for frameworks or libraries that support
 - [LangChain](https://js.langchain.com/): Framework for developing applications powered by large language models
 - [Mastra](https://mastra.ai/): TypeScript agent framework to build AI applications and features
 - [MCP TypeScript SDK](https://github.com/modelcontextprotocol/typescript-sdk): The official TypeScript SDK for the Model Context Protocol
-- [standard-tool](https://github.com/finom/standard-tool): One interface for an LLM tool, with Valibot schemas for its input and output
+- [standard-tool](https://standard-tool.js.org): One interface for an LLM tool, with Valibot schemas for its input and output
 
 ## Form libraries
 


### PR DESCRIPTION
`standard-tool` is a spec plus reference package for LLM tool definitions: a tool carries its `name`, `description`, `inputSchema` / `outputSchema`, and `execute`. The schemas are consumed through Standard Schema, so Valibot works directly for validation, and `@valibot/to-json-schema` supplies the JSON Schema sent to the model.

Added to the existing **AI libraries** category, in alphabetical order. Prettier check passes on the website workspace.

- Docs: https://standard-tool.js.org
- Repo: https://github.com/finom/standard-tool


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the `standard-tool` link in the AI libraries section of the ecosystem guide to point to its official website.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->