### PR TITLE
fix(zod-to-valibot): migrate standalone `z.partial(schema)` call

### DIFF
--- a/codemod/zod-to-valibot/CHANGELOG.md
+++ b/codemod/zod-to-valibot/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the library will be documented in this file.
 
 ## vX.X.X (Month DD, YYYY)
 
+- Fix codemod mangling standalone `z.partial(schema)` calls into `v.partial(v)` instead of `v.partial(schema)` (issue #1503)
 - Change build target to ES2020 so distributed output stays compatible with environments that lack support for newer syntax (pull request #1455)
 
 ## v0.1.2 (December 07, 2025)

--- a/codemod/zod-to-valibot/__testfixtures__/object-partial-static/input.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-partial-static/input.ts
@@ -1,0 +1,10 @@
+import { z } from "zod";
+
+const Foo = z.object({
+  foo: z.string(),
+});
+
+// standalone namespace form `z.partial(schema)` (see issue #1503)
+const xxx = z.partial(Foo).parse("xxx");
+const Partial = z.partial(Foo);
+const Inline = z.partial(z.object({ a: z.string(), b: z.number() }));

--- a/codemod/zod-to-valibot/__testfixtures__/object-partial-static/output.ts
+++ b/codemod/zod-to-valibot/__testfixtures__/object-partial-static/output.ts
@@ -1,0 +1,10 @@
+import * as v from "valibot";
+
+const Foo = v.object({
+  foo: v.string(),
+});
+
+// standalone namespace form `z.partial(schema)` (see issue #1503)
+const xxx = v.parse(v.partial(Foo), "xxx");
+const Partial = v.partial(Foo);
+const Inline = v.partial(v.object({ a: v.string(), b: v.number() }));

--- a/codemod/zod-to-valibot/src/test-setup.test.ts
+++ b/codemod/zod-to-valibot/src/test-setup.test.ts
@@ -45,6 +45,7 @@ defineTests(transform, [
   'object-merge',
   'object-omit',
   'object-partial',
+  'object-partial-static',
   'object-passthrough',
   'object-pick',
   'object-required',

--- a/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
+++ b/codemod/zod-to-valibot/src/transform/schemas-and-links/schemas-and-links.ts
@@ -582,12 +582,32 @@ function transformSchemasAndLinksHelper(
           objectModifier
         );
       } else if (isZodMethodName(propertyName)) {
-        transformedExp = toValibotMethodExp(
-          valibotIdentifier,
-          propertyName,
-          transformedExp ?? j.identifier(identifier),
-          cur.value.arguments
-        );
+        // Standalone namespace call such as `z.partial(Foo)`, as opposed to the
+        // method form `Foo.partial()`. Here the schema is the first argument
+        // rather than the receiver, so route that argument in as the schema
+        // instead of the namespace identifier (which produced `v.partial(v)`).
+        const isStandaloneNamespaceCall =
+          transformedExp === null &&
+          cur.value.callee.type === 'MemberExpression' &&
+          cur.value.callee.object.type === 'Identifier' &&
+          cur.value.callee.object.name === valibotIdentifier &&
+          cur.value.arguments.length > 0;
+        if (isStandaloneNamespaceCall) {
+          const [schemaArg, ...methodArgs] = cur.value.arguments;
+          transformedExp = toValibotMethodExp(
+            valibotIdentifier,
+            propertyName,
+            schemaArg as j.CallExpression | j.MemberExpression | j.Identifier,
+            methodArgs
+          );
+        } else {
+          transformedExp = toValibotMethodExp(
+            valibotIdentifier,
+            propertyName,
+            transformedExp ?? j.identifier(identifier),
+            cur.value.arguments
+          );
+        }
       } else if (isZodValidatorName(propertyName)) {
         if (curSchemaType === null) {
           // validators can only be applied to parsed schemas


### PR DESCRIPTION
Fixes #1503.

### Problem

The `zod-to-valibot` codemod only recognized the **method** form `schema.partial()`. For the **standalone namespace** form `z.partial(Foo)`, the AST traversal (`transformSchemasAndLinksHelper`) treated `partial` as a method invoked on the `v` namespace and passed the namespace identifier itself in as the schema — emitting broken output and dropping the real schema argument:

```ts
// input
const xxx = z.partial(Foo).parse("xxx");

// before (broken)
const xxx = v.parse(v.partial(v), "xxx");

// after (this PR)
const xxx = v.parse(v.partial(Foo), "xxx");
```

### Fix

In the method branch of the traversal, detect the standalone form — a known Zod method called directly on the namespace identifier with no receiver schema resolved yet — and route the first call argument in as the schema (remaining args stay as the method's args). This mirrors the existing method-form handling, so the same `transform*` helpers are reused unchanged.

### Tests

Added a `object-partial-static` fixture covering the reported case plus the plain (`z.partial(Foo)`) and inline (`z.partial(z.object({ … }))`) variants. `pnpm --filter @valibot/zod-to-valibot test` passes (72/72), and the existing method-form `object-partial` fixture is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed the Zod-to-Valibot codemod so standalone `z.partial(schema)` calls are correctly converted to `v.partial(schema)`.
  - Preserved correct handling for chained schema method transformations.
- **Tests**
  - Added coverage for standalone partial schemas used in parsed, assigned, and inline forms.
- **Documentation**
  - Documented the fix in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->