### PR TITLE
fix(cache): clone cached issues to stop issue paths from accumulating

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to the library will be documented in this file.
 - Fix `stringifyJson` action to preserve the dataset value when `JSON.stringify` returns `undefined` (pull request #1476)
 - Fix `literal` schema and `value`, `values`, `notValue` and `notValues` actions to treat `NaN` as equal to itself (pull request #1573)
 - Fix `intersect` schema to merge matching `NaN` values and invalid dates (pull request #1573)
+- Fix `cache` and `cacheAsync` methods to clone the issues of a cached dataset, preventing parent schemas from adding their path item to the same issue on every cache hit (pull request #1620)
 
 ## v1.4.2 (June 28, 2026)
 

--- a/library/src/methods/cache/cache.test.ts
+++ b/library/src/methods/cache/cache.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import { minLength, transform } from '../../actions/index.ts';
-import { string } from '../../schemas/index.ts';
+import { object, string } from '../../schemas/index.ts';
+import { getDotPath } from '../../utils/index.ts';
 import { pipe } from '../index.ts';
 import { cache, type SchemaWithCache } from './cache.ts';
 
@@ -80,6 +81,17 @@ describe('cache', () => {
         issues: undefined,
       });
       expect(runSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('without adding the issue path of a parent schema twice', () => {
+      const schema = object({ key: cache(pipe(string(), minLength(3))) });
+      const dotPaths: (string | null)[] = [];
+      for (let index = 0; index < 3; index++) {
+        const dataset = schema['~run']({ value: { key: 'fo' } }, {});
+        dotPaths.push(getDotPath(dataset.issues![0]));
+      }
+
+      expect(dotPaths).toStrictEqual(['key', 'key', 'key']);
     });
   });
 

--- a/library/src/methods/cache/cacheAsync.test.ts
+++ b/library/src/methods/cache/cacheAsync.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi } from 'vitest';
 import { minLength, transformAsync } from '../../actions/index.ts';
-import { string } from '../../schemas/index.ts';
+import { objectAsync, string } from '../../schemas/index.ts';
+import { getDotPath } from '../../utils/index.ts';
 import { pipe, pipeAsync } from '../index.ts';
 import { cacheAsync, type SchemaWithCacheAsync } from './cacheAsync.ts';
 
@@ -88,6 +89,19 @@ describe('cacheAsync', () => {
         }
       );
       expect(runSpy).toHaveBeenCalledTimes(1);
+    });
+
+    test('without adding the issue path of a parent schema twice', async () => {
+      const schema = objectAsync({
+        key: cacheAsync(pipe(string(), minLength(3))),
+      });
+      const dotPaths: (string | null)[] = [];
+      for (let index = 0; index < 3; index++) {
+        const dataset = await schema['~run']({ value: { key: 'fo' } }, {});
+        dotPaths.push(getDotPath(dataset.issues![0]));
+      }
+
+      expect(dotPaths).toStrictEqual(['key', 'key', 'key']);
     });
   });
 

--- a/library/src/utils/_cloneDataset/_cloneDataset.test.ts
+++ b/library/src/utils/_cloneDataset/_cloneDataset.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'vitest';
 import type {
   BaseIssue,
   FailureDataset,
+  ObjectPathItem,
   PartialDataset,
   SuccessDataset,
 } from '../../types/index.ts';
@@ -51,7 +52,7 @@ describe('_cloneDataset', () => {
     expect(clonedDataset).not.toBe(dataset);
     expect(clonedDataset.issues).toBeDefined();
     expect(clonedDataset.issues).not.toBe(dataset.issues);
-    expect(clonedDataset.issues![0]).toBe(issue);
+    expect(clonedDataset.issues![0]).not.toBe(issue);
   });
 
   test('should clone failure dataset issues array', () => {
@@ -80,5 +81,40 @@ describe('_cloneDataset', () => {
     expect(clonedDataset).not.toBe(dataset);
     expect(clonedDataset.issues).toBeDefined();
     expect(clonedDataset.issues).not.toBe(dataset.issues);
+    expect(clonedDataset.issues![0]).not.toBe(issue);
+  });
+
+  test('should clone path of dataset issues', () => {
+    const pathItem: ObjectPathItem = {
+      type: 'object',
+      origin: 'value',
+      input: { key: 123 },
+      key: 'key',
+      value: 123,
+    };
+    const issue: BaseIssue<unknown> = {
+      kind: 'schema',
+      type: 'string',
+      input: 123,
+      expected: 'string',
+      received: '123',
+      message: 'Invalid type: Expected string but received 123',
+      requirement: undefined,
+      path: [pathItem],
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+    const dataset: FailureDataset<BaseIssue<unknown>> = {
+      typed: false,
+      value: { key: 123 },
+      issues: [issue],
+    };
+    const clonedDataset = _cloneDataset(dataset);
+
+    expect(clonedDataset).toStrictEqual(dataset);
+    expect(clonedDataset.issues![0].path).not.toBe(issue.path);
+    expect(clonedDataset.issues![0].path![0]).toBe(pathItem);
   });
 });

--- a/library/src/utils/_cloneDataset/_cloneDataset.ts
+++ b/library/src/utils/_cloneDataset/_cloneDataset.ts
@@ -3,10 +3,10 @@ import type { BaseIssue, OutputDataset } from '../../types/index.ts';
 /**
  * Creates a shallow copy of a dataset.
  *
- * Hint: The `value` is copied by reference, but the `issues` array is cloned
- * to avoid reusing mutable dataset state across multiple runs. Mutating a
- * returned object or array value can therefore affect later cache hits that
- * reuse the same cached output.
+ * Hint: The `value` is copied by reference, but the `issues` array, its issues
+ * and their `path` arrays are cloned to avoid reusing mutable dataset state
+ * across multiple runs. Mutating a returned object or array value can
+ * therefore affect later cache hits that reuse the same cached output.
  *
  * @param dataset The output dataset.
  *
@@ -22,6 +22,13 @@ export function _cloneDataset<TValue, TIssue extends BaseIssue<unknown>>(
   return {
     typed: dataset.typed,
     value: dataset.value,
-    issues: dataset.issues && [...dataset.issues],
+    // Hint: Parent schemas and the `forward` method add path items to the
+    // issues they receive. We therefore clone each issue and its `path` array,
+    // so that these mutations are not applied to the same issue again on every
+    // following run.
+    issues: dataset.issues?.map((issue) => ({
+      ...issue,
+      path: issue.path && [...issue.path],
+    })) as OutputDataset<TValue, TIssue>['issues'],
   };
 }

--- a/library/src/utils/_cloneDataset/_cloneDataset.ts
+++ b/library/src/utils/_cloneDataset/_cloneDataset.ts
@@ -18,7 +18,6 @@ export function _cloneDataset<TValue, TIssue extends BaseIssue<unknown>>(
 ): OutputDataset<TValue, TIssue> {
   // Hint: We assign the known dataset properties directly instead of using the
   // spread operator for better runtime performance.
-  // @ts-expect-error
   return {
     typed: dataset.typed,
     value: dataset.value,
@@ -26,9 +25,10 @@ export function _cloneDataset<TValue, TIssue extends BaseIssue<unknown>>(
     // issues they receive. We therefore clone each issue and its `path` array,
     // so that these mutations are not applied to the same issue again on every
     // following run.
+    // @ts-expect-error Array.map does not preserve the non-empty tuple type
     issues: dataset.issues?.map((issue) => ({
       ...issue,
       path: issue.path && [...issue.path],
-    })) as OutputDataset<TValue, TIssue>['issues'],
+    })),
   };
 }


### PR DESCRIPTION
A schema wrapped in `cache` that sits inside a parent schema grows an extra path item on its issues on every cache hit, so the reported path is wrong from the second parse onwards.

```ts
const schema = v.object({ key: v.cache(v.pipe(v.string(), v.minLength(3))) });

for (let index = 0; index < 3; index++) {
  const result = v.safeParse(schema, { key: 'fo' });
  console.log(v.getDotPath(result.issues![0]));
}
// key
// key.key
// key.key.key
```

`v.flatten` is affected the same way, which is how this shows up in form code: `{ nested: { key: [...] } }` on the first parse, then `{ nested: { 'key.key': [...] } }`, then `{ nested: { 'key.key.key': [...] } }`.

### Cause

`_cloneDataset` in `library/src/utils/_cloneDataset/_cloneDataset.ts` clones the `issues` array of the cached dataset but keeps the issue objects inside it:

```ts
issues: dataset.issues && [...dataset.issues],
```

Issues are mutable, and every parent schema mutates the ones it receives. For example `object` in `library/src/schemas/object/object.ts` does `issue.path.unshift(pathItem)` when a path already exists and `issue.path = [pathItem]` when it does not, and `forward` in `library/src/methods/forward/forward.ts` pushes onto the same array. Because `cache` and `cacheAsync` return the very same issue object on every hit, each parse appends its path item to the issue that is still sitting in the cache, and the path keeps growing. Cloning the array only prevents the parent from pushing further issues into the cached array, not from mutating the issues themselves.

The `path` array needs the same treatment as the issue object. When the cached schema already produces a path of its own, `unshift` mutates the array that the cached issue still points at.

### Fix

`_cloneDataset` now clones each issue and its `path` array, so a parent schema and `forward` mutate the returned copy instead of the cached one. `value` is still copied by reference, and the sub `issues` of an issue are untouched because no schema mutates those.

### Tests

`library/src/utils/_cloneDataset/_cloneDataset.test.ts` now asserts that the issues and their `path` arrays are copies rather than the originals, with the path items themselves still shared by reference. `library/src/methods/cache/cache.test.ts` and `library/src/methods/cache/cacheAsync.test.ts` each gain a regression test that parses the schema above three times and expects the dot path to stay `key`. All five assertions fail on `main` and pass with this change.

### Verification

`pnpm test` in `library`: 530 files, 4609 tests passed, no type errors. `pnpm lint` in `library` (`eslint`, `tsc --noEmit`, `deno check ./src/index.ts`) and `pnpm format.check` both pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repeated validation runs with cached schemas incorrectly duplicating parent paths in reported issues.
  * Cached validation results now preserve consistent issue paths across repeated synchronous and asynchronous checks.
  * Improved isolation of cached issue data to prevent changes from carrying over between validation runs.
  * Ensured cached validation issues remain stable and accurate across multiple repeated checks.

* **Documentation**
  * Added a changelog entry describing the corrected cached-validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->