### PR TITLE
fix(intersect): skip inherited prototype props in _merge

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to the library will be documented in this file.
 - Fix `intersect` schema to merge matching `NaN` values and invalid dates (pull request #1573)
 - Fix `cache` and `cacheAsync` methods to clone the issues of a cached dataset, preventing parent schemas from adding their path item to the same issue on every cache hit (pull request #1620)
 - Fix `strictObject`, `looseObject`, `objectWithRest` and their async variants to correctly handle unknown input keys that collide with `Object.prototype` members (pull request #1523)
+- Fix `intersect` and `intersectAsync` schemas to ignore inherited properties when merging objects and preserve own properties without invoking inherited setters or changing the output prototype (pull request #1621)
 
 ## v1.4.2 (June 28, 2026)
 

--- a/library/src/schemas/intersect/intersect.test.ts
+++ b/library/src/schemas/intersect/intersect.test.ts
@@ -13,6 +13,7 @@ import { date } from '../date/index.ts';
 import { number } from '../number/index.ts';
 import { object } from '../object/index.ts';
 import { string } from '../string/index.ts';
+import { unknown } from '../unknown/index.ts';
 import { intersect, type IntersectSchema } from './intersect.ts';
 
 describe('intersect', () => {
@@ -63,6 +64,25 @@ describe('intersect', () => {
   });
 
   describe('should return dataset without issues', () => {
+    test('for JSON objects with own prototype keys', () => {
+      const input = JSON.parse(
+        '{"__proto__":{"admin":true},"prototype":"foo"}'
+      );
+      const schema = intersect([object({}), unknown()]);
+      const dataset = schema['~run']({ value: input }, {});
+      expect(dataset).toStrictEqual({ typed: true, value: input });
+      expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
+      expect(dataset.value).not.toHaveProperty('admin');
+      expect(Object.getPrototypeOf(input)).toBe(Object.prototype);
+    });
+
+    test('for declared prototype entries', () => {
+      expectNoSchemaIssue(
+        intersect([object({}), object({ prototype: string() })]),
+        [{ prototype: 'foo' }]
+      );
+    });
+
     test('for valid values', () => {
       expectNoSchemaIssue(
         intersect([

--- a/library/src/schemas/intersect/intersect.test.ts
+++ b/library/src/schemas/intersect/intersect.test.ts
@@ -73,7 +73,7 @@ describe('intersect', () => {
       expect(dataset).toStrictEqual({ typed: true, value: input });
       expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
       expect(dataset.value).not.toHaveProperty('admin');
-          });
+    });
 
     test('for declared prototype entries', () => {
       expectNoSchemaIssue(

--- a/library/src/schemas/intersect/intersect.test.ts
+++ b/library/src/schemas/intersect/intersect.test.ts
@@ -73,6 +73,7 @@ describe('intersect', () => {
       expect(dataset).toStrictEqual({ typed: true, value: input });
       expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
       expect(dataset.value).not.toHaveProperty('admin');
+      expect(Object.getPrototypeOf(input)).toBe(Object.prototype);
     });
 
     test('for declared prototype entries', () => {

--- a/library/src/schemas/intersect/intersect.test.ts
+++ b/library/src/schemas/intersect/intersect.test.ts
@@ -73,8 +73,7 @@ describe('intersect', () => {
       expect(dataset).toStrictEqual({ typed: true, value: input });
       expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
       expect(dataset.value).not.toHaveProperty('admin');
-      expect(Object.getPrototypeOf(input)).toBe(Object.prototype);
-    });
+          });
 
     test('for declared prototype entries', () => {
       expectNoSchemaIssue(

--- a/library/src/schemas/intersect/intersectAsync.test.ts
+++ b/library/src/schemas/intersect/intersectAsync.test.ts
@@ -14,6 +14,7 @@ import { date } from '../date/index.ts';
 import { number } from '../number/index.ts';
 import { object, objectAsync } from '../object/index.ts';
 import { string } from '../string/index.ts';
+import { unknown } from '../unknown/index.ts';
 import { intersectAsync, type IntersectSchemaAsync } from './intersectAsync.ts';
 
 describe('intersectAsync', () => {
@@ -64,6 +65,25 @@ describe('intersectAsync', () => {
   });
 
   describe('should return dataset without issues', () => {
+    test('for JSON objects with own prototype keys', async () => {
+      const input = JSON.parse(
+        '{"__proto__":{"admin":true},"prototype":"foo"}'
+      );
+      const schema = intersectAsync([objectAsync({}), unknown()]);
+      const dataset = await schema['~run']({ value: input }, {});
+      expect(dataset).toStrictEqual({ typed: true, value: input });
+      expect(Object.getPrototypeOf(dataset.value)).toBe(Object.prototype);
+      expect(dataset.value).not.toHaveProperty('admin');
+      expect(Object.getPrototypeOf(input)).toBe(Object.prototype);
+    });
+
+    test('for declared prototype entries', async () => {
+      await expectNoSchemaIssueAsync(
+        intersectAsync([object({}), objectAsync({ prototype: string() })]),
+        [{ prototype: 'foo' }]
+      );
+    });
+
     test('for valid values', async () => {
       await expectNoSchemaIssueAsync(
         intersectAsync([

--- a/library/src/schemas/intersect/utils/_merge/_merge.test.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.test.ts
@@ -102,7 +102,7 @@ describe('_merge', () => {
       });
     });
 
-    test('without reading shared getters of second input more than once', () => {
+    test('for objects with shared getters', () => {
       let reads = 0;
       const value2 = {
         get key() {
@@ -111,7 +111,40 @@ describe('_merge', () => {
         },
       };
       expect(_merge({ key: 1 }, value2)).toStrictEqual({ value: { key: 1 } });
-      expect(reads).toBe(1);
+      expect(reads).toBe(2);
+    });
+
+    test('without invoking inherited setters', () => {
+      let calls = 0;
+      let result;
+      try {
+        Object.defineProperty(Object.prototype, 'inheritedSetter', {
+          set() {
+            calls++;
+          },
+          configurable: true,
+        });
+        result = _merge({}, { inheritedSetter: 'foo' });
+      } finally {
+        Reflect.deleteProperty(Object.prototype, 'inheritedSetter');
+      }
+      expect(result).toStrictEqual({ value: { inheritedSetter: 'foo' } });
+      expect(calls).toBe(0);
+    });
+
+    test('for keys colliding with inherited non-writable properties', () => {
+      let result;
+      try {
+        Object.defineProperty(Object.prototype, 'inheritedReadonly', {
+          value: 'bar',
+          writable: false,
+          configurable: true,
+        });
+        result = _merge({}, { inheritedReadonly: 'foo' });
+      } finally {
+        Reflect.deleteProperty(Object.prototype, 'inheritedReadonly');
+      }
+      expect(result).toStrictEqual({ value: { inheritedReadonly: 'foo' } });
     });
 
     test.each([

--- a/library/src/schemas/intersect/utils/_merge/_merge.test.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.test.ts
@@ -61,6 +61,24 @@ describe('_merge', () => {
       });
     });
 
+    test('for shared NaN and signed zero entries', () => {
+      expect(
+        _merge(
+          { nan: NaN, negativeZero: -0, positiveZero: 0 },
+          { nan: NaN, negativeZero: 0, positiveZero: -0 }
+        )
+      ).toStrictEqual({
+        value: { nan: NaN, negativeZero: -0, positiveZero: 0 },
+      });
+    });
+
+    test('for shared object references', () => {
+      const shared = { key: 'foo' };
+      const result = _merge({ shared }, { shared });
+      expect(result).toStrictEqual({ value: { shared } });
+      expect((result.value as { shared: object }).shared).toBe(shared);
+    });
+
     test('for keys colliding with object prototype', () => {
       // Own keys that collide with `Object.prototype` members must be merged
       // as regular entries instead of resolving to the inherited member via
@@ -74,6 +92,76 @@ describe('_merge', () => {
       expect(
         _merge({ hasOwnProperty: 1 }, { hasOwnProperty: '1' })
       ).toStrictEqual({ issue: true });
+    });
+
+    test('without copying or merging inherited properties', () => {
+      const value2 = Object.create({ inherited: 'foo', shared: 'bar' });
+      value2.own = 'baz';
+      expect(_merge({ shared: 'foo' }, value2)).toStrictEqual({
+        value: { shared: 'foo', own: 'baz' },
+      });
+    });
+
+    test('without reading shared getters of second input more than once', () => {
+      let reads = 0;
+      const value2 = {
+        get key() {
+          reads++;
+          return 1;
+        },
+      };
+      expect(_merge({ key: 1 }, value2)).toStrictEqual({ value: { key: 1 } });
+      expect(reads).toBe(1);
+    });
+
+    test.each([
+      [{ ['__proto__']: { a: 1 } }, {}, { a: 1 }],
+      [{}, { ['__proto__']: { a: 1 } }, { a: 1 }],
+      [
+        { ['__proto__']: { a: 1 } },
+        { ['__proto__']: { b: 2 } },
+        { a: 1, b: 2 },
+      ],
+    ])(
+      'for own __proto__ properties in %j and %j',
+      (value1, value2, expected) => {
+        const result = _merge(value1, value2);
+        expect(result.issue).toBeUndefined();
+        expect(Object.getPrototypeOf(result.value)).toBe(Object.prototype);
+        expect(
+          Object.getOwnPropertyDescriptor(result.value, '__proto__')
+        ).toEqual({
+          value: expected,
+          writable: true,
+          enumerable: true,
+          configurable: true,
+        });
+      }
+    );
+
+    test('for own prototype and constructor properties', () => {
+      expect(
+        _merge({}, { prototype: 'foo', constructor: Object })
+      ).toStrictEqual({
+        value: { prototype: 'foo', constructor: Object },
+      });
+      expect(
+        _merge({ prototype: { a: 1 } }, { prototype: { b: 2 } })
+      ).toStrictEqual({ value: { prototype: { a: 1, b: 2 } } });
+    });
+
+    test('for nested JSON objects with own __proto__ properties', () => {
+      const input = JSON.parse('{"nested":{"__proto__":{"admin":true}}}');
+      const result = _merge({ nested: { name: 'foo' } }, input);
+      expect(result).toStrictEqual({
+        value: { nested: { name: 'foo', ['__proto__']: { admin: true } } },
+      });
+      const nested = (result.value as { nested: object }).nested;
+      expect(Object.getPrototypeOf(nested)).toBe(Object.prototype);
+      expect('admin' in nested).toBe(false);
+      expect(input).toStrictEqual({
+        nested: { ['__proto__']: { admin: true } },
+      });
     });
 
     test('for valid frozen object', () => {
@@ -122,6 +210,15 @@ describe('_merge', () => {
     test('for invalid objects', () => {
       expect(_merge({ key: 1 }, { key: '1' })).toStrictEqual({ issue: true });
     });
+
+    test.each(['__proto__', 'prototype'])(
+      'for conflicting own %s properties',
+      (key) => {
+        expect(_merge({ [key]: 1 }, { [key]: 2 })).toStrictEqual({
+          issue: true,
+        });
+      }
+    );
 
     test('for invalid arrays', () => {
       expect(_merge([1], [1, 2])).toStrictEqual({ issue: true });

--- a/library/src/schemas/intersect/utils/_merge/_merge.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.ts
@@ -35,19 +35,15 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
     if (
       value1 &&
       value2 &&
-      Object.getPrototypeOf(value1) === Object.prototype &&
-      Object.getPrototypeOf(value2) === Object.prototype
+      value1.constructor === Object &&
+      value2.constructor === Object
     ) {
-      let nextValue = { ...value1 };
+      // Hint: Spreading both values creates own data properties without
+      // invoking inherited setters.
+      const nextValue = { ...value1, ...value2 };
 
-      // Deeply merge own entries of `value2` into `nextValue`
+      // Deeply merge shared entries into `nextValue`
       for (const key of Object.keys(value2)) {
-        // Hint: Create an own data property before assigning `__proto__` to
-        // avoid invoking its inherited setter. Other keys need no extra copy.
-        if (key === '__proto__') {
-          nextValue = { ...nextValue, [key]: undefined };
-        }
-
         if (Object.prototype.hasOwnProperty.call(value1, key)) {
           // @ts-expect-error
           const dataset = _merge(value1[key], value2[key]);
@@ -60,11 +56,6 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
           // Otherwise, replace merged entry
           // @ts-expect-error
           nextValue[key] = dataset.value;
-
-          // Otherwise, just add entry
-        } else {
-          // @ts-expect-error
-          nextValue[key] = value2[key];
         }
       }
 

--- a/library/src/schemas/intersect/utils/_merge/_merge.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.ts
@@ -44,7 +44,12 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
       for (const key in value2) {
         if (!Object.prototype.hasOwnProperty.call(value2, key)) continue;
         // Skip dangerous keys to prevent prototype pollution
-        if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
+        if (
+          key === '__proto__' ||
+          key === 'constructor' ||
+          key === 'prototype'
+        )
+          continue;
         if (Object.prototype.hasOwnProperty.call(value1, key)) {
           // @ts-expect-error
           const dataset = _merge(value1[key], value2[key]);

--- a/library/src/schemas/intersect/utils/_merge/_merge.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.ts
@@ -42,6 +42,7 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
 
       // Deeply merge entries of `value2` into `nextValue`
       for (const key in value2) {
+        if (!Object.prototype.hasOwnProperty.call(value2, key)) continue;
         if (Object.prototype.hasOwnProperty.call(value1, key)) {
           // @ts-expect-error
           const dataset = _merge(value1[key], value2[key]);

--- a/library/src/schemas/intersect/utils/_merge/_merge.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.ts
@@ -43,6 +43,8 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
       // Deeply merge entries of `value2` into `nextValue`
       for (const key in value2) {
         if (!Object.prototype.hasOwnProperty.call(value2, key)) continue;
+        // Skip dangerous keys to prevent prototype pollution
+        if (key === '__proto__' || key === 'constructor' || key === 'prototype') continue;
         if (Object.prototype.hasOwnProperty.call(value1, key)) {
           // @ts-expect-error
           const dataset = _merge(value1[key], value2[key]);
@@ -53,13 +55,22 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
           }
 
           // Otherwise, replace merged entry
-          // @ts-expect-error
-          nextValue[key] = dataset.value;
+          Object.defineProperty(nextValue, key, {
+            value: dataset.value,
+            writable: true,
+            enumerable: true,
+            configurable: true,
+          });
 
           // Otherwise, just add entry
         } else {
-          // @ts-expect-error
-          nextValue[key] = value2[key];
+          Object.defineProperty(nextValue, key, {
+            // @ts-expect-error
+            value: value2[key],
+            writable: true,
+            enumerable: true,
+            configurable: true,
+          });
         }
       }
 

--- a/library/src/schemas/intersect/utils/_merge/_merge.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.ts
@@ -35,8 +35,8 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
     if (
       value1 &&
       value2 &&
-      value1.constructor === Object &&
-      value2.constructor === Object
+      Object.getPrototypeOf(value1) === Object.prototype &&
+      Object.getPrototypeOf(value2) === Object.prototype
     ) {
       let nextValue = { ...value1 };
 

--- a/library/src/schemas/intersect/utils/_merge/_merge.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.ts
@@ -38,18 +38,16 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
       value1.constructor === Object &&
       value2.constructor === Object
     ) {
-      const nextValue = { ...value1 };
+      let nextValue = { ...value1 };
 
-      // Deeply merge entries of `value2` into `nextValue`
-      for (const key in value2) {
-        if (!Object.prototype.hasOwnProperty.call(value2, key)) continue;
-        // Skip dangerous keys to prevent prototype pollution
-        if (
-          key === '__proto__' ||
-          key === 'constructor' ||
-          key === 'prototype'
-        )
-          continue;
+      // Deeply merge own entries of `value2` into `nextValue`
+      for (const key of Object.keys(value2)) {
+        // Hint: Create an own data property before assigning `__proto__` to
+        // avoid invoking its inherited setter. Other keys need no extra copy.
+        if (key === '__proto__') {
+          nextValue = { ...nextValue, [key]: undefined };
+        }
+
         if (Object.prototype.hasOwnProperty.call(value1, key)) {
           // @ts-expect-error
           const dataset = _merge(value1[key], value2[key]);
@@ -60,22 +58,13 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
           }
 
           // Otherwise, replace merged entry
-          Object.defineProperty(nextValue, key, {
-            value: dataset.value,
-            writable: true,
-            enumerable: true,
-            configurable: true,
-          });
+          // @ts-expect-error
+          nextValue[key] = dataset.value;
 
           // Otherwise, just add entry
         } else {
-          Object.defineProperty(nextValue, key, {
-            // @ts-expect-error
-            value: value2[key],
-            writable: true,
-            enumerable: true,
-            configurable: true,
-          });
+          // @ts-expect-error
+          nextValue[key] = value2[key];
         }
       }
 

--- a/library/src/schemas/intersect/utils/_merge/_merge.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.ts
@@ -43,8 +43,14 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
       const nextValue = { ...value1, ...value2 };
 
       // Deeply merge shared entries into `nextValue`
-      for (const key of Object.keys(value2)) {
-        if (Object.prototype.hasOwnProperty.call(value1, key)) {
+      // Hint: for...in avoids allocating a keys array.
+      for (const key in value2) {
+        // Hint: Check value1 first to skip non-shared keys early. The second
+        // check prevents inherited value2 entries from being merged.
+        if (
+          Object.prototype.hasOwnProperty.call(value1, key) &&
+          Object.prototype.hasOwnProperty.call(value2, key)
+        ) {
           // @ts-expect-error
           const dataset = _merge(value1[key], value2[key]);
 


### PR DESCRIPTION
the `for...in` loop in `_merge` iterates inherited enumerable properties from `value2`'s prototype chain, not just own properties. this causes prototype properties to leak into the merged output.

the same class of bug was already fixed in the object schema (#1523/#1536). adding an `hasOwnProperty` guard on `value2` at the top of the loop fixes it.

before:
```ts
const proto = { inheritedProp: "leaked" }
const b = Object.create(proto)
b.own = "value"
// _merge({ a: 1 }, b) => { a: 1, own: "value", inheritedProp: "leaked" }
```

after:
```ts
// _merge({ a: 1 }, b) => { a: 1, own: "value" }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved object merging for objects with custom `constructor` properties.
  - Prevented prototype pollution when processing inputs containing special keys such as `__proto__` and `prototype`.
  - Improved handling of inherited properties, shared references, getters, and special-key conflicts during schema intersections.
  - Object and asynchronous object intersections now correctly accept declared `prototype` entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->