### PR TITLE
Support console.clear in playground

### DIFF
--- a/website/src/routes/playground/iframeCode.js
+++ b/website/src/routes/playground/iframeCode.js
@@ -135,6 +135,11 @@ window.onerror = (...args) => {
   };
 });
 
+// Clear logs in parent window
+console.clear = () => {
+  parent.postMessage({ type: 'clear' }, '*');
+};
+
 // Listen for code messages
 window.addEventListener('message', (event) => {
   if (event.data.type === 'code') {

--- a/website/src/routes/playground/index.tsx
+++ b/website/src/routes/playground/index.tsx
@@ -178,6 +178,10 @@ export default component$(() => {
    * Captures logs from the iframe.
    */
   const captureLogs = $((event: MessageEvent<MessageEventData>) => {
+    if (event.source !== iframeElement.value?.contentWindow) {
+      return;
+    }
+
     if (event.data.type === 'log') {
       logs.value = [...logs.value, event.data.log];
     } else if (event.data.type === 'clear') {

--- a/website/src/routes/playground/index.tsx
+++ b/website/src/routes/playground/index.tsx
@@ -33,10 +33,14 @@ import iframeCode from './iframeCode.js?raw';
 
 type LogLevel = 'log' | 'info' | 'debug' | 'warn' | 'error';
 
-type MessageEventData = {
-  type: 'log';
-  log: [LogLevel, string];
-};
+type MessageEventData =
+  | {
+      type: 'log';
+      log: [LogLevel, string];
+    }
+  | {
+      type: 'clear';
+    };
 
 export const head: DocumentHead = {
   title: 'Playground',
@@ -176,6 +180,8 @@ export default component$(() => {
   const captureLogs = $((event: MessageEvent<MessageEventData>) => {
     if (event.data.type === 'log') {
       logs.value = [...logs.value, event.data.log];
+    } else if (event.data.type === 'clear') {
+      logs.value = [];
     }
   });
 


### PR DESCRIPTION
## Summary

- forward `console.clear()` calls from the playground iframe
- clear the parent playground log output when the message is received
- extend the playground message type with a `clear` event

Fixes #1578

## Validation

- `pnpm build`
- `cd website && pnpm lint`
- `cd website && pnpm build.types`
- `cd website && pnpm exec prettier --check src/routes/playground/iframeCode.js src/routes/playground/index.tsx`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * The playground’s clear-console command now correctly clears captured log output.
  * Console clearing in the playground no longer affects the parent page’s console.
  * The playground now ignores log and clear-console messages from unauthorized sources, helping prevent unrelated windows from altering captured output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->