### PR TITLE
fix(object): treat inherited input properties as missing

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to the library will be documented in this file.
 - Fix `literal` schema and `value`, `values`, `notValue` and `notValues` actions to treat `NaN` as equal to itself (pull request #1573)
 - Fix `intersect` schema to merge matching `NaN` values and invalid dates (pull request #1573)
 - Fix `cache` and `cacheAsync` methods to clone the issues of a cached dataset, preventing parent schemas from adding their path item to the same issue on every cache hit (pull request #1620)
+- Change `object`, `strictObject`, `looseObject`, `objectWithRest` and their async variants to treat inherited input properties as missing
 
 ## v1.4.2 (June 28, 2026)
 

--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the library will be documented in this file.
 - Fix `literal` schema and `value`, `values`, `notValue` and `notValues` actions to treat `NaN` as equal to itself (pull request #1573)
 - Fix `intersect` schema to merge matching `NaN` values and invalid dates (pull request #1573)
 - Fix `cache` and `cacheAsync` methods to clone the issues of a cached dataset, preventing parent schemas from adding their path item to the same issue on every cache hit (pull request #1620)
-- Change `object`, `strictObject`, `looseObject`, `objectWithRest` and their async variants to treat inherited input properties as missing
+- Change `object`, `strictObject`, `looseObject`, `objectWithRest` and their async variants to treat inherited input properties as missing (pull request #1625)
 
 ## v1.4.2 (June 28, 2026)
 

--- a/library/src/schemas/looseObject/looseObject.test.ts
+++ b/library/src/schemas/looseObject/looseObject.test.ts
@@ -672,4 +672,85 @@ describe('looseObject', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should treat prototype member names as missing keys', () => {
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for a required entry named like an object prototype member', () => {
+      const schema = looseObject({ toString: string() });
+      const input = {};
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: {},
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'loose_object',
+            input: undefined,
+            expected: '"toString"',
+            received: 'undefined',
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key: 'toString',
+                value: undefined,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+
+    test('for an optional entry with a default named like an object prototype member', () => {
+      const schema = looseObject({ toString: optional(string(), 'foo') });
+      expect(schema['~run']({ value: {} }, {})).toStrictEqual({
+        typed: true,
+        value: { toString: 'foo' },
+      });
+    });
+  });
+
+  test('without reading inherited getters for required entries', () => {
+    let reads = 0;
+    class Input {
+      get key() {
+        reads++;
+        return 'foo';
+      }
+    }
+    const schema = looseObject({ key: string() });
+    const input = new Input();
+    const dataset = schema['~run']({ value: input }, {});
+    expect(dataset).toMatchObject({
+      typed: false,
+      value: {},
+      issues: [
+        {
+          input: undefined,
+          path: [{ origin: 'key', key: 'key', value: undefined }],
+        },
+      ],
+    });
+    expect(reads).toBe(0);
+  });
+
+  test('for own properties shadowing inherited values', () => {
+    const input = Object.create({ key: 123 });
+    input.key = 'foo';
+    const schema = looseObject({ key: string() });
+    expect(schema['~run']({ value: input }, {})).toStrictEqual({
+      typed: true,
+      value: { key: 'foo' },
+    });
+  });
 });

--- a/library/src/schemas/looseObject/looseObject.ts
+++ b/library/src/schemas/looseObject/looseObject.ts
@@ -105,21 +105,22 @@ export function looseObject(
         for (const key in this.entries) {
           const valueSchema = this.entries[key];
 
+          const isKeyPresent = Object.prototype.hasOwnProperty.call(input, key);
+
           // If key is present or its an optional schema with a default value,
           // parse input of key or default value
           if (
-            key in input ||
+            isKeyPresent ||
             ((valueSchema.type === 'exact_optional' ||
               valueSchema.type === 'optional' ||
               valueSchema.type === 'nullish') &&
               // @ts-expect-error
               valueSchema.default !== undefined)
           ) {
-            const value: unknown =
-              key in input
-                ? // @ts-expect-error
-                  input[key]
-                : getDefault(valueSchema);
+            const value: unknown = isKeyPresent
+              ? // @ts-expect-error
+                input[key]
+              : getDefault(valueSchema);
             const valueDataset = valueSchema['~run']({ value }, config);
 
             // If there are issues, capture them
@@ -186,8 +187,7 @@ export function looseObject(
                   origin: 'key',
                   input: input as Record<string, unknown>,
                   key,
-                  // @ts-expect-error
-                  value: input[key],
+                  value: undefined,
                 },
               ],
             });

--- a/library/src/schemas/looseObject/looseObjectAsync.test.ts
+++ b/library/src/schemas/looseObject/looseObjectAsync.test.ts
@@ -857,4 +857,85 @@ describe('looseObjectAsync', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should treat prototype member names as missing keys', () => {
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for a required entry named like an object prototype member', async () => {
+      const schema = looseObjectAsync({ toString: string() });
+      const input = {};
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: {},
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'loose_object',
+            input: undefined,
+            expected: '"toString"',
+            received: 'undefined',
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key: 'toString',
+                value: undefined,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+
+    test('for an optional entry with a default named like an object prototype member', async () => {
+      const schema = looseObjectAsync({ toString: optional(string(), 'foo') });
+      expect(await schema['~run']({ value: {} }, {})).toStrictEqual({
+        typed: true,
+        value: { toString: 'foo' },
+      });
+    });
+  });
+
+  test('without reading inherited getters for required entries', async () => {
+    let reads = 0;
+    class Input {
+      get key() {
+        reads++;
+        return 'foo';
+      }
+    }
+    const schema = looseObjectAsync({ key: string() });
+    const input = new Input();
+    const dataset = await schema['~run']({ value: input }, {});
+    expect(dataset).toMatchObject({
+      typed: false,
+      value: {},
+      issues: [
+        {
+          input: undefined,
+          path: [{ origin: 'key', key: 'key', value: undefined }],
+        },
+      ],
+    });
+    expect(reads).toBe(0);
+  });
+
+  test('for own properties shadowing inherited values', async () => {
+    const input = Object.create({ key: 123 });
+    input.key = 'foo';
+    const schema = looseObjectAsync({ key: string() });
+    expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+      typed: true,
+      value: { key: 'foo' },
+    });
+  });
 });

--- a/library/src/schemas/looseObject/looseObjectAsync.ts
+++ b/library/src/schemas/looseObject/looseObjectAsync.ts
@@ -109,19 +109,22 @@ export function looseObjectAsync(
         // parse input of key or default value asynchronously
         const valueDatasets = await Promise.all(
           Object.entries(this.entries).map(async ([key, valueSchema]) => {
+            const isKeyPresent = Object.prototype.hasOwnProperty.call(
+              input,
+              key
+            );
             if (
-              key in input ||
+              isKeyPresent ||
               ((valueSchema.type === 'exact_optional' ||
                 valueSchema.type === 'optional' ||
                 valueSchema.type === 'nullish') &&
                 // @ts-expect-error
                 valueSchema.default !== undefined)
             ) {
-              const value: unknown =
-                key in input
-                  ? // @ts-expect-error
-                    input[key]
-                  : await getDefault(valueSchema);
+              const value: unknown = isKeyPresent
+                ? // @ts-expect-error
+                  input[key]
+                : await getDefault(valueSchema);
               return [
                 key,
                 value,
@@ -129,13 +132,7 @@ export function looseObjectAsync(
                 await valueSchema['~run']({ value }, config),
               ] as const;
             }
-            return [
-              key,
-              // @ts-expect-error
-              input[key] as unknown,
-              valueSchema,
-              null,
-            ] as const;
+            return [key, undefined, valueSchema, null] as const;
           })
         );
 

--- a/library/src/schemas/object/object.test.ts
+++ b/library/src/schemas/object/object.test.ts
@@ -677,4 +677,85 @@ describe('object', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should treat prototype member names as missing keys', () => {
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for a required entry named like an object prototype member', () => {
+      const schema = object({ toString: string() });
+      const input = {};
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: {},
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'object',
+            input: undefined,
+            expected: '"toString"',
+            received: 'undefined',
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key: 'toString',
+                value: undefined,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+
+    test('for an optional entry with a default named like an object prototype member', () => {
+      const schema = object({ toString: optional(string(), 'foo') });
+      expect(schema['~run']({ value: {} }, {})).toStrictEqual({
+        typed: true,
+        value: { toString: 'foo' },
+      });
+    });
+  });
+
+  test('without reading inherited getters for required entries', () => {
+    let reads = 0;
+    class Input {
+      get key() {
+        reads++;
+        return 'foo';
+      }
+    }
+    const schema = object({ key: string() });
+    const input = new Input();
+    const dataset = schema['~run']({ value: input }, {});
+    expect(dataset).toMatchObject({
+      typed: false,
+      value: {},
+      issues: [
+        {
+          input: undefined,
+          path: [{ origin: 'key', key: 'key', value: undefined }],
+        },
+      ],
+    });
+    expect(reads).toBe(0);
+  });
+
+  test('for own properties shadowing inherited values', () => {
+    const input = Object.create({ key: 123 });
+    input.key = 'foo';
+    const schema = object({ key: string() });
+    expect(schema['~run']({ value: input }, {})).toStrictEqual({
+      typed: true,
+      value: { key: 'foo' },
+    });
+  });
 });

--- a/library/src/schemas/object/object.ts
+++ b/library/src/schemas/object/object.ts
@@ -108,21 +108,22 @@ export function object(
         for (const key in this.entries) {
           const valueSchema = this.entries[key];
 
+          const isKeyPresent = Object.prototype.hasOwnProperty.call(input, key);
+
           // If key is present or its an optional schema with a default value,
           // parse input of key or default value
           if (
-            key in input ||
+            isKeyPresent ||
             ((valueSchema.type === 'exact_optional' ||
               valueSchema.type === 'optional' ||
               valueSchema.type === 'nullish') &&
               // @ts-expect-error
               valueSchema.default !== undefined)
           ) {
-            const value: unknown =
-              key in input
-                ? // @ts-expect-error
-                  input[key]
-                : getDefault(valueSchema);
+            const value: unknown = isKeyPresent
+              ? // @ts-expect-error
+                input[key]
+              : getDefault(valueSchema);
             const valueDataset = valueSchema['~run']({ value }, config);
 
             // If there are issues, capture them
@@ -189,8 +190,7 @@ export function object(
                   origin: 'key',
                   input: input as Record<string, unknown>,
                   key,
-                  // @ts-expect-error
-                  value: input[key],
+                  value: undefined,
                 },
               ],
             });

--- a/library/src/schemas/object/objectAsync.test.ts
+++ b/library/src/schemas/object/objectAsync.test.ts
@@ -868,4 +868,85 @@ describe('objectAsync', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should treat prototype member names as missing keys', () => {
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for a required entry named like an object prototype member', async () => {
+      const schema = objectAsync({ toString: string() });
+      const input = {};
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: {},
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'object',
+            input: undefined,
+            expected: '"toString"',
+            received: 'undefined',
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key: 'toString',
+                value: undefined,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+
+    test('for an optional entry with a default named like an object prototype member', async () => {
+      const schema = objectAsync({ toString: optional(string(), 'foo') });
+      expect(await schema['~run']({ value: {} }, {})).toStrictEqual({
+        typed: true,
+        value: { toString: 'foo' },
+      });
+    });
+  });
+
+  test('without reading inherited getters for required entries', async () => {
+    let reads = 0;
+    class Input {
+      get key() {
+        reads++;
+        return 'foo';
+      }
+    }
+    const schema = objectAsync({ key: string() });
+    const input = new Input();
+    const dataset = await schema['~run']({ value: input }, {});
+    expect(dataset).toMatchObject({
+      typed: false,
+      value: {},
+      issues: [
+        {
+          input: undefined,
+          path: [{ origin: 'key', key: 'key', value: undefined }],
+        },
+      ],
+    });
+    expect(reads).toBe(0);
+  });
+
+  test('for own properties shadowing inherited values', async () => {
+    const input = Object.create({ key: 123 });
+    input.key = 'foo';
+    const schema = objectAsync({ key: string() });
+    expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+      typed: true,
+      value: { key: 'foo' },
+    });
+  });
 });

--- a/library/src/schemas/object/objectAsync.ts
+++ b/library/src/schemas/object/objectAsync.ts
@@ -112,19 +112,22 @@ export function objectAsync(
         // parse input of key or default value asynchronously
         const valueDatasets = await Promise.all(
           Object.entries(this.entries).map(async ([key, valueSchema]) => {
+            const isKeyPresent = Object.prototype.hasOwnProperty.call(
+              input,
+              key
+            );
             if (
-              key in input ||
+              isKeyPresent ||
               ((valueSchema.type === 'exact_optional' ||
                 valueSchema.type === 'optional' ||
                 valueSchema.type === 'nullish') &&
                 // @ts-expect-error
                 valueSchema.default !== undefined)
             ) {
-              const value: unknown =
-                key in input
-                  ? // @ts-expect-error
-                    input[key]
-                  : await getDefault(valueSchema);
+              const value: unknown = isKeyPresent
+                ? // @ts-expect-error
+                  input[key]
+                : await getDefault(valueSchema);
               return [
                 key,
                 value,
@@ -132,13 +135,7 @@ export function objectAsync(
                 await valueSchema['~run']({ value }, config),
               ] as const;
             }
-            return [
-              key,
-              // @ts-expect-error
-              input[key] as unknown,
-              valueSchema,
-              null,
-            ] as const;
+            return [key, undefined, valueSchema, null] as const;
           })
         );
 

--- a/library/src/schemas/objectWithRest/objectWithRest.test.ts
+++ b/library/src/schemas/objectWithRest/objectWithRest.test.ts
@@ -805,4 +805,88 @@ describe('objectWithRest', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should treat prototype member names as missing keys', () => {
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for a required entry named like an object prototype member', () => {
+      const schema = objectWithRest({ toString: string() }, string());
+      const input = {};
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: {},
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'object_with_rest',
+            input: undefined,
+            expected: '"toString"',
+            received: 'undefined',
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key: 'toString',
+                value: undefined,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+
+    test('for an optional entry with a default named like an object prototype member', () => {
+      const schema = objectWithRest(
+        { toString: optional(string(), 'foo') },
+        string()
+      );
+      expect(schema['~run']({ value: {} }, {})).toStrictEqual({
+        typed: true,
+        value: { toString: 'foo' },
+      });
+    });
+  });
+
+  test('without reading inherited getters for required entries', () => {
+    let reads = 0;
+    class Input {
+      get key() {
+        reads++;
+        return 'foo';
+      }
+    }
+    const schema = objectWithRest({ key: string() }, number());
+    const input = new Input();
+    const dataset = schema['~run']({ value: input }, {});
+    expect(dataset).toMatchObject({
+      typed: false,
+      value: {},
+      issues: [
+        {
+          input: undefined,
+          path: [{ origin: 'key', key: 'key', value: undefined }],
+        },
+      ],
+    });
+    expect(reads).toBe(0);
+  });
+
+  test('for own properties shadowing inherited values', () => {
+    const input = Object.create({ key: 123 });
+    input.key = 'foo';
+    const schema = objectWithRest({ key: string() }, number());
+    expect(schema['~run']({ value: input }, {})).toStrictEqual({
+      typed: true,
+      value: { key: 'foo' },
+    });
+  });
 });

--- a/library/src/schemas/objectWithRest/objectWithRest.ts
+++ b/library/src/schemas/objectWithRest/objectWithRest.ts
@@ -128,21 +128,22 @@ export function objectWithRest(
         for (const key in this.entries) {
           const valueSchema = this.entries[key];
 
+          const isKeyPresent = Object.prototype.hasOwnProperty.call(input, key);
+
           // If key is present or its an optional schema with a default value,
           // parse input of key or default value
           if (
-            key in input ||
+            isKeyPresent ||
             ((valueSchema.type === 'exact_optional' ||
               valueSchema.type === 'optional' ||
               valueSchema.type === 'nullish') &&
               // @ts-expect-error
               valueSchema.default !== undefined)
           ) {
-            const value: unknown =
-              key in input
-                ? // @ts-expect-error
-                  input[key]
-                : getDefault(valueSchema);
+            const value: unknown = isKeyPresent
+              ? // @ts-expect-error
+                input[key]
+              : getDefault(valueSchema);
             const valueDataset = valueSchema['~run']({ value }, config);
 
             // If there are issues, capture them
@@ -209,8 +210,7 @@ export function objectWithRest(
                   origin: 'key',
                   input: input as Record<string, unknown>,
                   key,
-                  // @ts-expect-error
-                  value: input[key],
+                  value: undefined,
                 },
               ],
             });

--- a/library/src/schemas/objectWithRest/objectWithRestAsync.test.ts
+++ b/library/src/schemas/objectWithRest/objectWithRestAsync.test.ts
@@ -995,4 +995,88 @@ describe('objectWithRestAsync', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should treat prototype member names as missing keys', () => {
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for a required entry named like an object prototype member', async () => {
+      const schema = objectWithRestAsync({ toString: string() }, string());
+      const input = {};
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: {},
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'object_with_rest',
+            input: undefined,
+            expected: '"toString"',
+            received: 'undefined',
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key: 'toString',
+                value: undefined,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+
+    test('for an optional entry with a default named like an object prototype member', async () => {
+      const schema = objectWithRestAsync(
+        { toString: optional(string(), 'foo') },
+        string()
+      );
+      expect(await schema['~run']({ value: {} }, {})).toStrictEqual({
+        typed: true,
+        value: { toString: 'foo' },
+      });
+    });
+  });
+
+  test('without reading inherited getters for required entries', async () => {
+    let reads = 0;
+    class Input {
+      get key() {
+        reads++;
+        return 'foo';
+      }
+    }
+    const schema = objectWithRestAsync({ key: string() }, number());
+    const input = new Input();
+    const dataset = await schema['~run']({ value: input }, {});
+    expect(dataset).toMatchObject({
+      typed: false,
+      value: {},
+      issues: [
+        {
+          input: undefined,
+          path: [{ origin: 'key', key: 'key', value: undefined }],
+        },
+      ],
+    });
+    expect(reads).toBe(0);
+  });
+
+  test('for own properties shadowing inherited values', async () => {
+    const input = Object.create({ key: 123 });
+    input.key = 'foo';
+    const schema = objectWithRestAsync({ key: string() }, number());
+    expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+      typed: true,
+      value: { key: 'foo' },
+    });
+  });
 });

--- a/library/src/schemas/objectWithRest/objectWithRestAsync.ts
+++ b/library/src/schemas/objectWithRest/objectWithRestAsync.ts
@@ -141,19 +141,22 @@ export function objectWithRestAsync(
           // parse input of key or default value asynchronously
           Promise.all(
             Object.entries(this.entries).map(async ([key, valueSchema]) => {
+              const isKeyPresent = Object.prototype.hasOwnProperty.call(
+                input,
+                key
+              );
               if (
-                key in input ||
+                isKeyPresent ||
                 ((valueSchema.type === 'exact_optional' ||
                   valueSchema.type === 'optional' ||
                   valueSchema.type === 'nullish') &&
                   // @ts-expect-error
                   valueSchema.default !== undefined)
               ) {
-                const value: unknown =
-                  key in input
-                    ? // @ts-expect-error
-                      input[key]
-                    : await getDefault(valueSchema);
+                const value: unknown = isKeyPresent
+                  ? // @ts-expect-error
+                    input[key]
+                  : await getDefault(valueSchema);
                 return [
                   key,
                   value,
@@ -161,13 +164,7 @@ export function objectWithRestAsync(
                   await valueSchema['~run']({ value }, config),
                 ] as const;
               }
-              return [
-                key,
-                // @ts-expect-error
-                input[key] as unknown,
-                valueSchema,
-                null,
-              ] as const;
+              return [key, undefined, valueSchema, null] as const;
             })
           ),
 

--- a/library/src/schemas/strictObject/strictObject.test.ts
+++ b/library/src/schemas/strictObject/strictObject.test.ts
@@ -696,4 +696,85 @@ describe('strictObject', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should treat prototype member names as missing keys', () => {
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for a required entry named like an object prototype member', () => {
+      const schema = strictObject({ toString: string() });
+      const input = {};
+      expect(schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: {},
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'strict_object',
+            input: undefined,
+            expected: '"toString"',
+            received: 'undefined',
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key: 'toString',
+                value: undefined,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+
+    test('for an optional entry with a default named like an object prototype member', () => {
+      const schema = strictObject({ toString: optional(string(), 'foo') });
+      expect(schema['~run']({ value: {} }, {})).toStrictEqual({
+        typed: true,
+        value: { toString: 'foo' },
+      });
+    });
+  });
+
+  test('without reading inherited getters for required entries', () => {
+    let reads = 0;
+    class Input {
+      get key() {
+        reads++;
+        return 'foo';
+      }
+    }
+    const schema = strictObject({ key: string() });
+    const input = new Input();
+    const dataset = schema['~run']({ value: input }, {});
+    expect(dataset).toMatchObject({
+      typed: false,
+      value: {},
+      issues: [
+        {
+          input: undefined,
+          path: [{ origin: 'key', key: 'key', value: undefined }],
+        },
+      ],
+    });
+    expect(reads).toBe(0);
+  });
+
+  test('for own properties shadowing inherited values', () => {
+    const input = Object.create({ key: 123 });
+    input.key = 'foo';
+    const schema = strictObject({ key: string() });
+    expect(schema['~run']({ value: input }, {})).toStrictEqual({
+      typed: true,
+      value: { key: 'foo' },
+    });
+  });
 });

--- a/library/src/schemas/strictObject/strictObject.ts
+++ b/library/src/schemas/strictObject/strictObject.ts
@@ -101,21 +101,22 @@ export function strictObject(
         for (const key in this.entries) {
           const valueSchema = this.entries[key];
 
+          const isKeyPresent = Object.prototype.hasOwnProperty.call(input, key);
+
           // If key is present or its an optional schema with a default value,
           // parse input of key or default value
           if (
-            key in input ||
+            isKeyPresent ||
             ((valueSchema.type === 'exact_optional' ||
               valueSchema.type === 'optional' ||
               valueSchema.type === 'nullish') &&
               // @ts-expect-error
               valueSchema.default !== undefined)
           ) {
-            const value: unknown =
-              key in input
-                ? // @ts-expect-error
-                  input[key]
-                : getDefault(valueSchema);
+            const value: unknown = isKeyPresent
+              ? // @ts-expect-error
+                input[key]
+              : getDefault(valueSchema);
             const valueDataset = valueSchema['~run']({ value }, config);
 
             // If there are issues, capture them
@@ -182,8 +183,7 @@ export function strictObject(
                   origin: 'key',
                   input: input as Record<string, unknown>,
                   key,
-                  // @ts-expect-error
-                  value: input[key],
+                  value: undefined,
                 },
               ],
             });

--- a/library/src/schemas/strictObject/strictObjectAsync.test.ts
+++ b/library/src/schemas/strictObject/strictObjectAsync.test.ts
@@ -873,4 +873,85 @@ describe('strictObjectAsync', () => {
       } satisfies FailureDataset<InferIssue<typeof schema>>);
     });
   });
+
+  describe('should treat prototype member names as missing keys', () => {
+    const baseInfo = {
+      message: expect.any(String),
+      requirement: undefined,
+      issues: undefined,
+      lang: undefined,
+      abortEarly: undefined,
+      abortPipeEarly: undefined,
+    };
+
+    test('for a required entry named like an object prototype member', async () => {
+      const schema = strictObjectAsync({ toString: string() });
+      const input = {};
+      expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+        typed: false,
+        value: {},
+        issues: [
+          {
+            ...baseInfo,
+            kind: 'schema',
+            type: 'strict_object',
+            input: undefined,
+            expected: '"toString"',
+            received: 'undefined',
+            path: [
+              {
+                type: 'object',
+                origin: 'key',
+                input,
+                key: 'toString',
+                value: undefined,
+              },
+            ],
+          },
+        ],
+      } satisfies FailureDataset<InferIssue<typeof schema>>);
+    });
+
+    test('for an optional entry with a default named like an object prototype member', async () => {
+      const schema = strictObjectAsync({ toString: optional(string(), 'foo') });
+      expect(await schema['~run']({ value: {} }, {})).toStrictEqual({
+        typed: true,
+        value: { toString: 'foo' },
+      });
+    });
+  });
+
+  test('without reading inherited getters for required entries', async () => {
+    let reads = 0;
+    class Input {
+      get key() {
+        reads++;
+        return 'foo';
+      }
+    }
+    const schema = strictObjectAsync({ key: string() });
+    const input = new Input();
+    const dataset = await schema['~run']({ value: input }, {});
+    expect(dataset).toMatchObject({
+      typed: false,
+      value: {},
+      issues: [
+        {
+          input: undefined,
+          path: [{ origin: 'key', key: 'key', value: undefined }],
+        },
+      ],
+    });
+    expect(reads).toBe(0);
+  });
+
+  test('for own properties shadowing inherited values', async () => {
+    const input = Object.create({ key: 123 });
+    input.key = 'foo';
+    const schema = strictObjectAsync({ key: string() });
+    expect(await schema['~run']({ value: input }, {})).toStrictEqual({
+      typed: true,
+      value: { key: 'foo' },
+    });
+  });
 });

--- a/library/src/schemas/strictObject/strictObjectAsync.ts
+++ b/library/src/schemas/strictObject/strictObjectAsync.ts
@@ -105,19 +105,22 @@ export function strictObjectAsync(
         // parse input of key or default value asynchronously
         const valueDatasets = await Promise.all(
           Object.entries(this.entries).map(async ([key, valueSchema]) => {
+            const isKeyPresent = Object.prototype.hasOwnProperty.call(
+              input,
+              key
+            );
             if (
-              key in input ||
+              isKeyPresent ||
               ((valueSchema.type === 'exact_optional' ||
                 valueSchema.type === 'optional' ||
                 valueSchema.type === 'nullish') &&
                 // @ts-expect-error
                 valueSchema.default !== undefined)
             ) {
-              const value: unknown =
-                key in input
-                  ? // @ts-expect-error
-                    input[key]
-                  : await getDefault(valueSchema);
+              const value: unknown = isKeyPresent
+                ? // @ts-expect-error
+                  input[key]
+                : await getDefault(valueSchema);
               return [
                 key,
                 value,
@@ -125,13 +128,7 @@ export function strictObjectAsync(
                 await valueSchema['~run']({ value }, config),
               ] as const;
             }
-            return [
-              key,
-              // @ts-expect-error
-              input[key] as unknown,
-              valueSchema,
-              null,
-            ] as const;
+            return [key, undefined, valueSchema, null] as const;
           })
         );
 


### PR DESCRIPTION
Moves the inherited-input changes from #1523 into a separate draft for review after v1.5, preserving the original contributor's authorship.

Currently, parsing `object({ toString: optional(string(), 'fallback') })` with `{}` validates the inherited `Object.prototype.toString` function and fails instead of applying the default. This proposal uses an inline own-property check in all eight object schema implementations: inherited values are treated as missing, optional defaults and fallbacks can apply, and missing-key issue paths contain `undefined` without reading inherited getters.

**This is a proposal, not ready to merge.** Two points need resolution:

- **Compatibility:** inherited fields and class getters that currently satisfy required entries will be rejected. The new tests make that behavior explicit; the intended inheritance policy and release compatibility need a decision.
- **Declared `__proto__` output:** the existing output assignments still invoke its inherited setter. For example, `object({ ['__proto__']: optional(unknown(), { admin: true }) })` with `{}` produces an output that inherits `admin` rather than owning a `__proto__` data property. The output paths need safe handling before this proposal is ready.

The existing strict unknown-key enumeration and synchronous enumeration of schema entries also deserve consistency review alongside this ownership policy.

Validation: the original 16 missing-key/default regressions fail on the base branch. With this proposal, all 4,641 library tests, type checks, ESLint, Deno checks, and formatting pass. Additional tests cover inherited getters not being invoked and own properties shadowing inherited values.

Initial local Node v24.15.0 benchmarks of minified synchronous parsers showed 13–45% higher throughput for the tested numeric-object workloads (3, 10, and 50 declared keys, plus cases with rest keys). The fixture containing four synchronous schema factories, `number`, and `parse` grew by 144 minified bytes / 7 gzip bytes. These are limited local measurements; broader runtime and workload coverage remains part of review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Object schemas now treat inherited properties as missing during validation.
  - Required inherited keys correctly report missing-key errors.
  - Optional inherited keys receive configured defaults.
  - Inherited getters are no longer accessed, while own properties continue to be validated normally.
  - Behavior is consistent across synchronous and asynchronous object schemas.

- **Documentation**
  - Updated the unreleased changelog with these object-property handling changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->