### PR TITLE
fix(intersect): support own constructor properties

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to the library will be documented in this file.
 - Fix `cache` and `cacheAsync` methods to clone the issues of a cached dataset, preventing parent schemas from adding their path item to the same issue on every cache hit (pull request #1620)
 - Fix `strictObject`, `looseObject`, `objectWithRest` and their async variants to correctly handle unknown input keys that collide with `Object.prototype` members (pull request #1523)
 - Fix `intersect` and `intersectAsync` schemas to ignore inherited properties when merging objects and preserve own properties without invoking inherited setters or changing the output prototype (pull request #1621)
+- Fix `intersect` and `intersectAsync` schemas to merge objects with own `constructor` properties without rejecting valid inputs
 - Fix `ulid` action to reject ULIDs that exceed the maximum 128-bit value (pull request #1498)
 - Fix `email` action to reject non-ASCII characters accepted by Unicode case folding (pull request #1075)
 

--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -14,7 +14,7 @@ All notable changes to the library will be documented in this file.
 - Fix `cache` and `cacheAsync` methods to clone the issues of a cached dataset, preventing parent schemas from adding their path item to the same issue on every cache hit (pull request #1620)
 - Fix `strictObject`, `looseObject`, `objectWithRest` and their async variants to correctly handle unknown input keys that collide with `Object.prototype` members (pull request #1523)
 - Fix `intersect` and `intersectAsync` schemas to ignore inherited properties when merging objects and preserve own properties without invoking inherited setters or changing the output prototype (pull request #1621)
-- Fix `intersect` and `intersectAsync` schemas to merge objects with own `constructor` properties without rejecting valid inputs
+- Fix `intersect` and `intersectAsync` schemas to merge objects with own `constructor` properties without rejecting valid inputs (pull request #1626)
 - Fix `ulid` action to reject ULIDs that exceed the maximum 128-bit value (pull request #1498)
 - Fix `email` action to reject non-ASCII characters accepted by Unicode case folding (pull request #1075)
 

--- a/library/src/schemas/intersect/intersect.test.ts
+++ b/library/src/schemas/intersect/intersect.test.ts
@@ -83,6 +83,16 @@ describe('intersect', () => {
       );
     });
 
+    test('for declared constructor entries', () => {
+      expectNoSchemaIssue(
+        intersect([
+          object({ key: number() }),
+          object({ constructor: string() }),
+        ]),
+        [{ key: 123, constructor: 'foo' }]
+      );
+    });
+
     test('for valid values', () => {
       expectNoSchemaIssue(
         intersect([

--- a/library/src/schemas/intersect/intersectAsync.test.ts
+++ b/library/src/schemas/intersect/intersectAsync.test.ts
@@ -84,6 +84,16 @@ describe('intersectAsync', () => {
       );
     });
 
+    test('for declared constructor entries', async () => {
+      await expectNoSchemaIssueAsync(
+        intersectAsync([
+          object({ key: number() }),
+          objectAsync({ constructor: string() }),
+        ]),
+        [{ key: 123, constructor: 'foo' }]
+      );
+    });
+
     test('for valid values', async () => {
       await expectNoSchemaIssueAsync(
         intersectAsync([

--- a/library/src/schemas/intersect/utils/_merge/_merge.test.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.test.ts
@@ -183,6 +183,54 @@ describe('_merge', () => {
       ).toStrictEqual({ value: { prototype: { a: 1, b: 2 } } });
     });
 
+    test.each(['foo', 123, null, undefined])(
+      'for own constructor property with value %j',
+      (constructor) => {
+        const value = { constructor };
+        expect(_merge(value, {})).toStrictEqual({ value });
+        expect(_merge({}, value)).toStrictEqual({ value });
+        expect(_merge(value, { constructor })).toStrictEqual({ value });
+      }
+    );
+
+    test('for own function constructor properties', () => {
+      expect(_merge({}, { constructor: Array })).toStrictEqual({
+        value: { constructor: Array },
+      });
+    });
+
+    test('for nested constructor properties', () => {
+      const result = _merge(
+        { constructor: { a: 1 } },
+        { constructor: { b: 2 } }
+      );
+      expect(result).toEqual({ value: { constructor: { a: 1, b: 2 } } });
+      expect(Object.getPrototypeOf(result.value)).toBe(Object.prototype);
+      expect(
+        _merge({ nested: { constructor: 'foo' } }, { nested: { key: 1 } })
+      ).toStrictEqual({ value: { nested: { constructor: 'foo', key: 1 } } });
+    });
+
+    test('for own constructor properties on custom-prototype objects', () => {
+      const value = Object.create({ inherited: 'bar' });
+      value.constructor = 'foo';
+      expect(_merge(value, { key: 1 })).toStrictEqual({
+        value: { constructor: 'foo', key: 1 },
+      });
+      expect(_merge({ key: 1 }, value)).toStrictEqual({
+        value: { key: 1, constructor: 'foo' },
+      });
+    });
+
+    test('for Object.prototype', () => {
+      expect(_merge(Object.prototype, { key: 1 })).toStrictEqual({
+        value: { key: 1 },
+      });
+      expect(_merge({ key: 1 }, Object.prototype)).toStrictEqual({
+        value: { key: 1 },
+      });
+    });
+
     test('for nested JSON objects with own __proto__ properties', () => {
       const input = JSON.parse('{"nested":{"__proto__":{"admin":true}}}');
       const result = _merge({ nested: { name: 'foo' } }, input);
@@ -244,7 +292,7 @@ describe('_merge', () => {
       expect(_merge({ key: 1 }, { key: '1' })).toStrictEqual({ issue: true });
     });
 
-    test.each(['__proto__', 'prototype'])(
+    test.each(['__proto__', 'prototype', 'constructor'])(
       'for conflicting own %s properties',
       (key) => {
         expect(_merge({ [key]: 1 }, { [key]: 2 })).toStrictEqual({
@@ -252,6 +300,20 @@ describe('_merge', () => {
         });
       }
     );
+
+    test('for class instances', () => {
+      class TestClass {
+        key = 'foo';
+      }
+      expect(_merge(new TestClass(), new TestClass())).toStrictEqual({
+        issue: true,
+      });
+    });
+
+    test('for objects without prototypes', () => {
+      expect(_merge(Object.create(null), {})).toStrictEqual({ issue: true });
+      expect(_merge({}, Object.create(null))).toStrictEqual({ issue: true });
+    });
 
     test('for invalid arrays', () => {
       expect(_merge([1], [1, 2])).toStrictEqual({ issue: true });

--- a/library/src/schemas/intersect/utils/_merge/_merge.ts
+++ b/library/src/schemas/intersect/utils/_merge/_merge.ts
@@ -32,11 +32,15 @@ export function _merge(value1: unknown, value2: unknown): MergeDataset {
     }
 
     // Return deeply merged object
+    // Hint: Keep the fast constructor check and fall back to the prototype
+    // when an own constructor property shadows Object.
     if (
       value1 &&
       value2 &&
-      value1.constructor === Object &&
-      value2.constructor === Object
+      (value1.constructor === Object ||
+        Object.getPrototypeOf(value1)?.constructor === Object) &&
+      (value2.constructor === Object ||
+        Object.getPrototypeOf(value2)?.constructor === Object)
     ) {
       // Hint: Spreading both values creates own data properties without
       // invoking inherited setters.


### PR DESCRIPTION
Objects with data such as `{ constructor: 'foo' }` currently fail intersection merging because the own property shadows `Object`. This change falls back to the prototype's constructor when the existing check fails, allowing these fields to be preserved and recursively merged while retaining the normal fast path and existing custom-prototype support.

Follow-up to #1621, originally contributed by @ItzXynx, addressing the remaining [constructor review feedback](https://github.com/open-circle/valibot/pull/1621#discussion_r3962208007). This avoids the compatibility regression from requiring the immediate prototype to equal `Object.prototype`.

Validation: all 4,701 library tests, type checks, lint, formatting, and build pass. Nine regression tests fail before the fix and pass afterward; coverage includes both sync and async intersections, nested/shared constructor data, and custom prototypes. Ordinary parsing benchmarks remain within about 2% of the current implementation on Node 24.15 and Bun 1.3.13. The parsing fixture adds 100 minified bytes / 12 gzip bytes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed synchronous and asynchronous schema intersections to accept valid objects with their own `constructor` property.
  * Improved object merging for objects with shadowed `constructor` properties.
  * Preserved validation errors for unsupported class instances and non-plain objects.

* **Documentation**
  * Added an unreleased changelog entry describing the intersection schema fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->