### PR TITLE
chore: prepare Valibot v1.5.0 release

### DIFF
--- a/library/CHANGELOG.md
+++ b/library/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.5.0 (September 09, 2026)
 
 - Add `codePoints`, `maxCodePoints`, `minCodePoints` and `notCodePoints` validation actions to validate the number of Unicode code points (pull request #888)
 - Add `ksuid` validation action to validate KSUIDs (pull request #1370)

--- a/library/jsr.json
+++ b/library/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@valibot/valibot",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "exports": "./src/index.ts",
   "publish": {
     "include": ["src/**/*.ts", "README.md"],

--- a/library/package.json
+++ b/library/package.json
@@ -1,7 +1,7 @@
 {
   "name": "valibot",
   "description": "The modular and type safe schema library for validating structural data",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://valibot.dev",


### PR DESCRIPTION
Prepare Valibot v1.5.0 by updating the npm and JSR package versions and dating the changelog September 9, 2026.

The release includes code-point validators, KSUID validation, Standard Schema and URL performance improvements, and fixes for JSON serialization, NaN equality, cached issue paths, object-key collisions, intersection merging, ULIDs, and email validation. Follow-up changes in #1625 and #1626 are deferred.

Validation: all 4,688 library tests, TypeScript and Deno checks, ESLint, formatting, and the build pass. All four JavaScript distribution entry points passed smoke checks, and an npm pack dry run verified the package version and contents.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added validation actions for Unicode code points and KSUIDs.
- **Improvements**
  - Improved performance and compatibility across several schema validation features, including URLs, JSON stringification, literals, intersections, caching, object schemas, ULIDs, and email validation.
- **Release**
  - Published version 1.5.0 with updated release documentation and package metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->