### PR TITLE
fix(ci): unblock release workflow validation

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,6 +11,10 @@ permissions:
 jobs:
   default_ci:
     name: Run default CI of repository
+    permissions:
+      contents: read
+      # Required by the reusable workflow's PR preview job, even when skipped.
+      pull-requests: write
     uses: ./.github/workflows/ci.yml
 
   library_npm:


### PR DESCRIPTION
Publishing v1.5.0 failed before any jobs started because the reusable CI workflow's `library_preview` job requests `pull-requests: write`, while the calling job only allows `contents: read`. GitHub validates this permission requirement even when the preview job is skipped for release events.

Grant `pull-requests: write` only to the `default_ci` caller job and explain why it is required. The preview remains restricted to pull request events.

Validation: parsed both workflows and reproduced the original permission mismatch; the updated caller covers every permission requested by the CI jobs. Prettier and `git diff --check` pass.

After merging, manually dispatch Publish from the corrected `main` to retry v1.5.0. The original release run references the old workflow commit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflow permissions to support pull request preview checks.
  - No changes were made to the product’s features, functionality, or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->