### PR TITLE
fix(forward): stop forwarding only on undefined, not all falsy values

### DIFF
--- a/library/src/methods/forward/forward.test.ts
+++ b/library/src/methods/forward/forward.test.ts
@@ -201,6 +201,84 @@ describe('forward', () => {
     >);
   });
 
+
+  test('should stop forwarding if path input is null', () => {
+    const input = { nested: null };
+    type Input = { nested: null };
+    const requirement = () => false;
+    expect(
+      forward<Input, CheckIssue<Input>, ['nested', 'key']>(
+        check(requirement, 'message'),
+        ['nested', 'key']
+      )['~run']({ typed: true, value: input }, {})
+    ).toStrictEqual({
+      typed: true,
+      value: input,
+      issues: [
+        {
+          kind: 'validation',
+          type: 'check',
+          input,
+          expected: null,
+          received: 'Object',
+          message: 'message',
+          path: [
+            {
+              type: 'unknown',
+              origin: 'value',
+              input: input,
+              key: 'nested',
+              value: null,
+            },
+          ],
+          requirement,
+          issues: undefined,
+          lang: undefined,
+          abortEarly: undefined,
+          abortPipeEarly: undefined,
+        },
+      ],
+    } satisfies PartialDataset<Input, CheckIssue<Input>>);
+  });
+
+  test('should not stop forwarding if intermediate value is 0', () => {
+    const input = { count: 0 };
+    type Input = { count: number };
+    const requirement = () => false;
+    expect(
+      forward<Input, CheckIssue<Input>, ['count']>(
+        check(requirement, 'message'),
+        ['count']
+      )['~run']({ typed: true, value: input }, {})
+    ).toStrictEqual({
+      typed: true,
+      value: input,
+      issues: [
+        {
+          kind: 'validation',
+          type: 'check',
+          input,
+          expected: null,
+          received: 'Object',
+          message: 'message',
+          path: [
+            {
+              type: 'unknown',
+              origin: 'value',
+              input: input,
+              key: 'count',
+              value: 0,
+            },
+          ],
+          requirement,
+          issues: undefined,
+          lang: undefined,
+          abortEarly: undefined,
+          abortPipeEarly: undefined,
+        },
+      ],
+    } satisfies PartialDataset<Input, CheckIssue<Input>>);
+  });
   test('should do nothing if there are no issues', () => {
     const input = { nested: [{ key: 'value_1' }, { key: 'value_2' }] };
     type Input = typeof input;

--- a/library/src/methods/forward/forward.test.ts
+++ b/library/src/methods/forward/forward.test.ts
@@ -204,7 +204,7 @@ describe('forward', () => {
 
   test('should stop forwarding if path input is null', () => {
     const input = { nested: null };
-    type Input = { nested: null };
+    interface Input { nested: null }
     const requirement = () => false;
     expect(
       forward<Input, CheckIssue<Input>, ['nested', 'key']>(
@@ -243,7 +243,7 @@ describe('forward', () => {
 
   test('should not stop forwarding if intermediate value is 0', () => {
     const input = { count: 0 };
-    type Input = { count: number };
+    interface Input { count: number }
     const requirement = () => false;
     expect(
       forward<Input, CheckIssue<Input>, ['count']>(

--- a/library/src/methods/forward/forward.ts
+++ b/library/src/methods/forward/forward.ts
@@ -68,8 +68,8 @@ export function forward<
                 issue.path = [pathItem];
               }
 
-              // If path value is undefined, stop forwarding
-              if (pathValue === undefined) {
+              // If path value is nullish, stop forwarding
+              if (pathValue === undefined || pathValue === null) {
                 break;
               }
 

--- a/library/src/methods/forward/forward.ts
+++ b/library/src/methods/forward/forward.ts
@@ -49,7 +49,7 @@ export function forward<
             for (const key of path) {
               // Create path value variable
               // @ts-expect-error
-              const pathValue: unknown = pathInput[key];
+              const pathValue: unknown = pathInput != null ? pathInput[key] : undefined;
 
               // Create path item for current key
               const pathItem: IssuePathItem = {

--- a/library/src/methods/forward/forward.ts
+++ b/library/src/methods/forward/forward.ts
@@ -69,7 +69,7 @@ export function forward<
               }
 
               // If path value is undefined, stop forwarding
-              if (!pathValue) {
+              if (pathValue === undefined) {
                 break;
               }
 

--- a/library/src/methods/forward/forwardAsync.test.ts
+++ b/library/src/methods/forward/forwardAsync.test.ts
@@ -201,7 +201,7 @@ describe('forwardAsync', () => {
 
   test('should stop forwarding if path input is null', async () => {
     const input = { nested: null };
-    type Input = { nested: null };
+    interface Input { nested: null }
     const requirement = () => false;
     expect(
       await forwardAsync<Input, CheckIssue<Input>, ['nested', 'key']>(
@@ -240,7 +240,7 @@ describe('forwardAsync', () => {
 
   test('should not stop forwarding if intermediate value is 0', async () => {
     const input = { count: 0 };
-    type Input = { count: number };
+    interface Input { count: number }
     const requirement = () => false;
     expect(
       await forwardAsync<Input, CheckIssue<Input>, ['count']>(

--- a/library/src/methods/forward/forwardAsync.test.ts
+++ b/library/src/methods/forward/forwardAsync.test.ts
@@ -198,6 +198,84 @@ describe('forwardAsync', () => {
     >);
   });
 
+
+  test('should stop forwarding if path input is null', async () => {
+    const input = { nested: null };
+    type Input = { nested: null };
+    const requirement = () => false;
+    expect(
+      await forwardAsync<Input, CheckIssue<Input>, ['nested', 'key']>(
+        check(requirement, 'message'),
+        ['nested', 'key']
+      )['~run']({ typed: true, value: input }, {})
+    ).toStrictEqual({
+      typed: true,
+      value: input,
+      issues: [
+        {
+          kind: 'validation',
+          type: 'check',
+          input,
+          expected: null,
+          received: 'Object',
+          message: 'message',
+          path: [
+            {
+              type: 'unknown',
+              origin: 'value',
+              input: input,
+              key: 'nested',
+              value: null,
+            },
+          ],
+          requirement,
+          issues: undefined,
+          lang: undefined,
+          abortEarly: undefined,
+          abortPipeEarly: undefined,
+        },
+      ],
+    } satisfies PartialDataset<Input, CheckIssue<Input>>);
+  });
+
+  test('should not stop forwarding if intermediate value is 0', async () => {
+    const input = { count: 0 };
+    type Input = { count: number };
+    const requirement = () => false;
+    expect(
+      await forwardAsync<Input, CheckIssue<Input>, ['count']>(
+        check(requirement, 'message'),
+        ['count']
+      )['~run']({ typed: true, value: input }, {})
+    ).toStrictEqual({
+      typed: true,
+      value: input,
+      issues: [
+        {
+          kind: 'validation',
+          type: 'check',
+          input,
+          expected: null,
+          received: 'Object',
+          message: 'message',
+          path: [
+            {
+              type: 'unknown',
+              origin: 'value',
+              input: input,
+              key: 'count',
+              value: 0,
+            },
+          ],
+          requirement,
+          issues: undefined,
+          lang: undefined,
+          abortEarly: undefined,
+          abortPipeEarly: undefined,
+        },
+      ],
+    } satisfies PartialDataset<Input, CheckIssue<Input>>);
+  });
   test('should do nothing if there are no issues', async () => {
     const input = { nested: [{ key: 'value_1' }, { key: 'value_2' }] };
     type Input = typeof input;

--- a/library/src/methods/forward/forwardAsync.ts
+++ b/library/src/methods/forward/forwardAsync.ts
@@ -53,7 +53,7 @@ export function forwardAsync<
             for (const key of path) {
               // Create path value variable
               // @ts-expect-error
-              const pathValue: unknown = pathInput[key];
+              const pathValue: unknown = pathInput != null ? pathInput[key] : undefined;
 
               // Create path item for current key
               const pathItem: IssuePathItem = {
@@ -72,8 +72,8 @@ export function forwardAsync<
                 issue.path = [pathItem];
               }
 
-              // If path value is undefined, stop forwarding
-              if (!pathValue) {
+              // If path value is nullish, stop forwarding
+              if (pathValue === undefined || pathValue === null) {
                 break;
               }
 


### PR DESCRIPTION
`!pathValue` stops on `0`, `false`, `''` in the middle of a path, cutting it short. also throws `TypeError` when an intermediate value is `null` since `null[key]` crashes.

changed to `pathValue === undefined || pathValue === null` in both `forward` and `forwardAsync`. also added null-safe read so `null` input yields `undefined` instead of throwing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of nested paths when values are `null` or `undefined`, preventing errors during traversal.
  * Preserved traversal for valid falsy values such as `false`, `0`, and empty strings.
  * Ensured synchronous and asynchronous forwarding produce consistent results when encountering nullish or falsy intermediate values.

* **Tests**
  * Added coverage for null path values and traversable falsy values to help prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->