### PR TITLE
perf: optimize Luhn and ISBN validation

### DIFF
--- a/library/src/actions/isbn/utils/_isIsbn10.test.ts
+++ b/library/src/actions/isbn/utils/_isIsbn10.test.ts
@@ -20,5 +20,6 @@ describe('_isIsbn10', () => {
     expect(_isIsbn10('0975229801')).toBe(false);
     expect(_isIsbn10('0684843286')).toBe(false);
     expect(_isIsbn10('1566199094')).toBe(false);
+    expect(_isIsbn10('03064061a2')).toBe(false);
   });
 });

--- a/library/src/actions/isbn/utils/_isIsbn10.ts
+++ b/library/src/actions/isbn/utils/_isIsbn10.ts
@@ -8,10 +8,16 @@
  * @internal
  */
 export function _isIsbn10(input: string): boolean {
-  const digits = input.split('').map((c) => (c === 'X' ? 10 : parseInt(c)));
   let sum = 0;
   for (let i = 0; i < 10; i++) {
-    sum += digits[i] * (10 - i);
+    const charCode = input.charCodeAt(i);
+    if (charCode === 88) {
+      sum += 10 * (10 - i);
+    } else if (charCode >= 48 && charCode <= 57) {
+      sum += (charCode - 48) * (10 - i);
+    } else {
+      return false;
+    }
   }
   return sum % 11 === 0;
 }

--- a/library/src/actions/isbn/utils/_isIsbn13.test.ts
+++ b/library/src/actions/isbn/utils/_isIsbn13.test.ts
@@ -13,6 +13,7 @@ describe('_isIsbn13', () => {
   });
 
   test('should return false', () => {
+    expect(_isIsbn13('9780306406X57')).toBe(false);
     expect(_isIsbn13('9780306406158')).toBe(false);
     expect(_isIsbn13('9780451526534')).toBe(false);
     expect(_isIsbn13('9780007149682')).toBe(false);

--- a/library/src/actions/isbn/utils/_isIsbn13.ts
+++ b/library/src/actions/isbn/utils/_isIsbn13.ts
@@ -8,10 +8,13 @@
  * @internal
  */
 export function _isIsbn13(input: string): boolean {
-  const digits = input.split('').map((c) => parseInt(c));
   let sum = 0;
   for (let i = 0; i < 13; i++) {
-    sum += digits[i] * (i % 2 === 0 ? 1 : 3);
+    const charCode = input.charCodeAt(i);
+    if (charCode < 48 || charCode > 57) {
+      return false;
+    }
+    sum += (charCode - 48) * (i % 2 === 0 ? 1 : 3);
   }
   return sum % 10 === 0;
 }

--- a/library/src/utils/_isLuhnAlgo/_isLuhnAlgo.test.ts
+++ b/library/src/utils/_isLuhnAlgo/_isLuhnAlgo.test.ts
@@ -3,6 +3,8 @@ import { _isLuhnAlgo } from './_isLuhnAlgo.ts';
 
 describe('_isLuhnAlgo', () => {
   test('should return true', () => {
+    expect(_isLuhnAlgo('53-649845-919122-6')).toBe(true);
+    expect(_isLuhnAlgo('53 649845 919122 6')).toBe(true);
     expect(_isLuhnAlgo('536498459191226')).toBe(true);
     expect(_isLuhnAlgo('860548042618881')).toBe(true);
     expect(_isLuhnAlgo('304517506893326')).toBe(true);

--- a/library/src/utils/_isLuhnAlgo/_isLuhnAlgo.ts
+++ b/library/src/utils/_isLuhnAlgo/_isLuhnAlgo.ts
@@ -1,9 +1,4 @@
 /**
- * Non-digit regex.
- */
-const NON_DIGIT_REGEX = /\D/gu;
-
-/**
  * Checks whether a string with numbers corresponds to the luhn algorithm.
  *
  * @param input The input to be checked.
@@ -14,19 +9,19 @@ const NON_DIGIT_REGEX = /\D/gu;
  */
 // @__NO_SIDE_EFFECTS__
 export function _isLuhnAlgo(input: string): boolean {
-  // Remove any non-digit chars
-  const number = input.replace(NON_DIGIT_REGEX, '');
-
   // Create necessary variables
-  let length = number.length;
+  let index = input.length;
   let bit = 1;
   let sum = 0;
 
   // Calculate sum of algorithm
-  while (length) {
-    const value = +number[--length];
-    bit ^= 1;
-    sum += bit ? [0, 2, 4, 6, 8, 1, 3, 5, 7, 9][value] : value;
+  while (index) {
+    const charCode = input.charCodeAt(--index);
+    if (charCode >= 48 && charCode <= 57) {
+      const value = charCode - 48;
+      bit ^= 1;
+      sum += bit ? (value > 4 ? value * 2 - 9 : value * 2) : value;
+    }
   }
 
   // Return whether its valid


### PR DESCRIPTION
# Optimize Luhn and ISBN validation

## Summary

This change reduces allocations and repeated work in several validation actions
without changing their public validation rules.

## Changes

- Optimize `_isLuhnAlgo` with a single `charCodeAt` pass over the input.
  Separators are skipped without creating an intermediate string or lookup
  array.
- Optimize ISBN-10 and ISBN-13 checksum calculation with fixed loops and
  character-code conversion instead of `split().map(parseInt)`.

## Benchmark results

Benchmarks were run locally against the implementation before and after the
changes. The benchmark files are intentionally not part of this PR.

| Workload                             | Improvement |
| ------------------------------------ | ----------: |
| Luhn through `creditCard` and `imei` |  1.13–1.61x |
| ISBN-10 and ISBN-13                  |  1.18–1.41x |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - ISBN-10 and ISBN-13 validation now rejects invalid characters consistently.
  - ISBN checksum validation continues to follow established checksum rules.
  - Luhn validation supports values containing spaces or hyphens as separators.
  - Validation results remain consistent with existing checksum requirements.

- **Tests**
  - Added coverage for invalid characters in ISBN values.
  - Added coverage for Luhn-validated values formatted with spaces or hyphens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->