### PR TITLE
chore: prepare to-json-schema v1.8.0 release

### DIFF
--- a/packages/to-json-schema/CHANGELOG.md
+++ b/packages/to-json-schema/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to the library will be documented in this file.
 
-## vX.X.X (Month DD, YYYY)
+## v1.8.0 (September 11, 2026)
 
 - Add support for `ksuid` action (pull request #1370)
 - Add passthrough of other `metadata` action properties to support custom annotations and standard keywords like `format`, which take precedence over generated properties (pull request #1591)
@@ -19,6 +19,7 @@ All notable changes to the library will be documented in this file.
 - Fix `minValue`, `maxValue`, `gtValue` and `ltValue` actions to skip numeric constraints on unsupported types in `warn` and `ignore` error modes (pull request #1595)
 - Fix generation of reference IDs for `lazy` schemas to produce consistent output and avoid collisions with existing definitions (pull request #1604)
 - Change `ConversionContext.referenceMap` type from `Map` to its `ReferenceMap` subclass (pull request #1604)
+- Change Valibot peer dependency to v1.5.0
 
 ## v1.7.1 (June 08, 2026)
 

--- a/packages/to-json-schema/jsr.json
+++ b/packages/to-json-schema/jsr.json
@@ -1,6 +1,6 @@
 {
   "name": "@valibot/to-json-schema",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "exports": "./src/index.ts",
   "publish": {
     "include": ["src/**/*.ts", "README.md"],

--- a/packages/to-json-schema/package.json
+++ b/packages/to-json-schema/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@valibot/to-json-schema",
   "description": "The official JSON schema converter for Valibot",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "license": "MIT",
   "author": "Fabian Hiller",
   "homepage": "https://valibot.dev",
@@ -64,12 +64,12 @@
     "tsdown": "^0.16.6",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.47.0",
-    "valibot": "^1.4.0",
+    "valibot": "^1.5.0",
     "vite": "^7.2.4",
     "vite-tsconfig-paths": "^5.1.4",
     "vitest": "4.1.8"
   },
   "peerDependencies": {
-    "valibot": "^1.4.0"
+    "valibot": "^1.5.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,8 +180,8 @@ importers:
         specifier: ^8.47.0
         version: 8.47.0(eslint@9.39.1(jiti@2.6.1))(typescript@5.9.3)
       valibot:
-        specifier: ^1.4.0
-        version: 1.4.0(typescript@5.9.3)
+        specifier: ^1.5.0
+        version: 1.5.0(typescript@5.9.3)
       vite:
         specifier: ^7.2.4
         version: 7.2.4(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(tsx@4.19.2)(yaml@2.8.1)
@@ -6329,6 +6329,14 @@ packages:
 
   valibot@1.4.0:
     resolution: {integrity: sha512-iC/x7fVcSyOwlm/VSt7RlHnzNGLGvR9GnxdifUeWoCJo0q4ZZvrVkIHC6faTlkxG47I2Y4UrFquPuVHCrOnrLg==}
+    peerDependencies:
+      typescript: '>=5'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  valibot@1.5.0:
+    resolution: {integrity: sha512-nil6AkP2TChWL43Z5uJ6GTxX01CUA+g8LWUM+N/rB9NBbkUMaUsi9PUNzlUPgoKASgmx9f7eGOYpJ04/fSa6FQ==}
     peerDependencies:
       typescript: '>=5'
     peerDependenciesMeta:
@@ -13018,6 +13026,10 @@ snapshots:
   v8-compile-cache-lib@3.0.1: {}
 
   valibot@1.4.0(typescript@5.9.3):
+    optionalDependencies:
+      typescript: 5.9.3
+
+  valibot@1.5.0(typescript@5.9.3):
     optionalDependencies:
       typescript: 5.9.3
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -3,7 +3,7 @@ packages:
   - 'library'
   - 'packages/*'
   - 'website'
-minimumReleaseAge: 10080  # minutes — 7 days
+minimumReleaseAge: 10080 # minutes — 7 days
 allowBuilds:
   '@ast-grep/cli': true
   '@vercel/speed-insights': true
@@ -22,6 +22,7 @@ minimumReleaseAgeExclude:
   - workerd@1.20260616.1
   - wrangler@4.101.0
   - tar@7.5.21
+  - valibot@1.5.0
 overrides:
   # Security: pin vulnerable transitive deps to patched versions (CVE Lite findings).
   # Keyed by major so only the affected major line is moved to its fixed version.


### PR DESCRIPTION
Prepare `@valibot/to-json-schema` v1.8.0 after merging the selected converter fixes (#1595, #1604, #1611, #1613, and #1612).

- Bump npm and JSR versions from 1.7.1 to 1.8.0 and finalize the changelog for September 11, 2026.
- Raise the Valibot development and peer dependency to `^1.5.0` for the newly supported `ksuid` action, and update its lockfile resolution.

The release includes `ksuid` and expanded metadata support, preservation of repeated bounds and value restrictions, JSON compatibility fixes, and collision-free lazy reference IDs. The changelog also records the `ConversionContext.referenceMap` type change and stricter handling of unsupported values.

Validation: all 315 package tests, ESLint, TypeScript, Deno, Prettier, build, and `git diff --check` pass. Confirmed npm/JSR version and lockfile consistency. Packed the npm artifact and verified ESM/CommonJS runtime imports and both declaration formats against published Valibot 1.5.0, including `ksuid` conversion.

This PR prepares the release; package publishing remains a separate step.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release**
  - Released `@valibot/to-json-schema` version 1.8.0.

- **Compatibility**
  - Updated compatibility to support Valibot version 1.5.0 and compatible releases.
  - Updated package metadata to reflect the new Valibot peer dependency requirement.

- **Documentation**
  - Updated the changelog with the 1.8.0 release date and dependency compatibility details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->