### PR TITLE
feat(to-json-schema): support code point string constraints

### DIFF
--- a/packages/to-json-schema/README.md
+++ b/packages/to-json-schema/README.md
@@ -58,6 +58,7 @@ This package is particularly popular for:
 | --------------- | ------ | ------------------------------------------------------ |
 | `base64`        | ✅     |                                                        |
 | `bic`           | ✅     |                                                        |
+| `codePoints`    | ✅     |                                                        |
 | `cuid2`         | ✅     |                                                        |
 | `decimal`       | ✅     |                                                        |
 | `description`   | ✅     |                                                        |
@@ -86,21 +87,24 @@ This package is particularly popular for:
 | `isrc`          | ✅     |                                                        |
 | `jwsCompact`    | ✅     |                                                        |
 | `ksuid`         | ✅     |                                                        |
-| `length`        | ⚠️     | Only in combination with `string` and `array` schema   |
+| `length`        | ⚠️     | Deprecated for strings; use `codePoints`; arrays are supported |
 | `ltValue`       | ⚠️     | Only in combination with `number` and `integer` schema |
 | `mac`           | ✅     |                                                        |
 | `mac48`         | ✅     |                                                        |
 | `mac64`         | ✅     |                                                        |
+| `maxCodePoints` | ✅     |                                                        |
 | `maxEntries`    | ✅     |                                                        |
-| `maxLength`     | ⚠️     | Only in combination with `string` and `array` schema   |
+| `maxLength`     | ⚠️     | Deprecated for strings; use `maxCodePoints`; arrays are supported |
 | `maxValue`      | ⚠️     | Only in combination with `number` schema               |
 | `metadata`      | ✅     | Additional properties are added without validation     |
+| `minCodePoints` | ✅     |                                                        |
 | `minEntries`    | ✅     |                                                        |
-| `minLength`     | ⚠️     | Only in combination with `string` and `array` schema   |
+| `minLength`     | ⚠️     | Deprecated for strings; use `minCodePoints`; arrays are supported |
 | `minValue`      | ⚠️     | Only in combination with `number` schema               |
 | `multipleOf`    | ✅     |                                                        |
 | `nanoid`        | ✅     |                                                        |
 | `nonEmpty`      | ✅     |                                                        |
+| `notCodePoints` | ✅     |                                                        |
 | `notValue`      | ⚠️     | Only JSON compatible values are supported              |
 | `notValues`     | ⚠️     | Only JSON compatible values are supported              |
 | `octal`         | ✅     |                                                        |
@@ -116,7 +120,7 @@ This package is particularly popular for:
 | `value`         | ⚠️     | Only JSON compatible values are supported              |
 | `values`        | ⚠️     | Only JSON compatible values are supported              |
 
-> For `length`, `minLength`, and `maxLength`, string constraints have different length semantics in Valibot and JSON Schema. Valibot checks JavaScript string length (`value.length`, UTF-16 code units), while JSON Schema `minLength` and `maxLength` count Unicode code points. This can differ for non-BMP code points such as emoji and for multi-code-point grapheme clusters such as combining marks or ZWJ sequences.
+> For string schemas, `length`, `minLength`, and `maxLength` have different length semantics in Valibot and JSON Schema. Valibot checks JavaScript string length (`value.length`, UTF-16 code units), while JSON Schema `minLength` and `maxLength` count Unicode code points. Their string conversion is deprecated and will be removed in v2. Use `codePoints`, `minCodePoints`, `maxCodePoints`, and `notCodePoints` for matching semantics. Set `errorMode` to `warn` to receive a runtime deprecation warning. This can differ for non-BMP code points such as emoji and for multi-code-point grapheme clusters such as combining marks or ZWJ sequences.
 
 ## Configurations
 

--- a/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
+++ b/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
@@ -792,7 +792,7 @@ describe('convertAction', () => {
       [v.codePoints<string, 3>(3), { minLength: 3, maxLength: 3 }],
       [v.maxCodePoints<string, 3>(3), { maxLength: 3 }],
       [v.minCodePoints<string, 3>(3), { minLength: 3 }],
-      [v.notCodePoints<string, 3>(3), { not: { minLength: 3, maxLength: 3 } }],
+      [v.notCodePoints<string, 3>(3), {}],
     ] as const;
     for (const [action, expected] of actions) {
       expect(convertAction({}, action, { errorMode: 'warn' })).toStrictEqual(
@@ -809,7 +809,7 @@ describe('convertAction', () => {
       [v.codePoints<string, 3>(3), { minLength: 3, maxLength: 3 }],
       [v.maxCodePoints<string, 3>(3), { maxLength: 3 }],
       [v.minCodePoints<string, 3>(3), { minLength: 3 }],
-      [v.notCodePoints<string, 3>(3), { not: { minLength: 3, maxLength: 3 } }],
+      [v.notCodePoints<string, 3>(3), {}],
     ] as const;
     for (const [action, expected] of actions) {
       expect(convertAction({}, action, { errorMode: 'ignore' })).toStrictEqual(

--- a/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
+++ b/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
@@ -656,6 +656,168 @@ describe('convertAction', () => {
     });
   });
 
+  test('should convert code points actions for strings', () => {
+    expect(
+      convertAction({ type: 'string' }, v.codePoints<string, 3>(3), undefined)
+    ).toStrictEqual({
+      type: 'string',
+      minLength: 3,
+      maxLength: 3,
+    });
+    expect(
+      convertAction(
+        { type: 'string' },
+        v.maxCodePoints<string, 3>(3),
+        undefined
+      )
+    ).toStrictEqual({
+      type: 'string',
+      maxLength: 3,
+    });
+    expect(
+      convertAction(
+        { type: 'string' },
+        v.minCodePoints<string, 3>(3),
+        undefined
+      )
+    ).toStrictEqual({
+      type: 'string',
+      minLength: 3,
+    });
+    expect(
+      convertAction(
+        { type: 'string' },
+        v.notCodePoints<string, 3>(3),
+        undefined
+      )
+    ).toStrictEqual({
+      type: 'string',
+      not: { minLength: 3, maxLength: 3 },
+    });
+  });
+
+  test('should warn for deprecated string length actions', () => {
+    const actions = [
+      [v.length<v.LengthInput, 3>(3), 'length', 'codePoints'],
+      [v.maxLength<v.LengthInput, 3>(3), 'maxLength', 'maxCodePoints'],
+      [v.minLength<v.LengthInput, 3>(3), 'minLength', 'minCodePoints'],
+    ] as const;
+    for (const [action, actionName, replacementName] of actions) {
+      convertAction({ type: 'string' }, action, { errorMode: 'warn' });
+      expect(console.warn).toHaveBeenLastCalledWith(
+        `The "${actionName}" action is deprecated for string schemas because Valibot counts UTF-16 code units while JSON Schema counts Unicode code points. Use "${replacementName}" instead.`
+      );
+    }
+  });
+
+  test('should not warn for length actions on arrays', () => {
+    vi.clearAllMocks();
+    for (const action of [
+      v.length<v.LengthInput, 3>(3),
+      v.maxLength<v.LengthInput, 3>(3),
+      v.minLength<v.LengthInput, 3>(3),
+    ]) {
+      convertAction({ type: 'array' }, action, { errorMode: 'warn' });
+    }
+    expect(console.warn).not.toHaveBeenCalled();
+  });
+
+  test('should keep stricter bounds for code points actions', () => {
+    expect(
+      convertAction(
+        { type: 'string', minLength: 5 },
+        v.minCodePoints<string, 3>(3),
+        undefined
+      )
+    ).toStrictEqual({
+      type: 'string',
+      minLength: 5,
+    });
+    expect(
+      convertAction(
+        { type: 'string', maxLength: 3 },
+        v.maxCodePoints<string, 5>(5),
+        undefined
+      )
+    ).toStrictEqual({
+      type: 'string',
+      maxLength: 3,
+    });
+    expect(
+      convertAction(
+        { type: 'string', minLength: 3, maxLength: 5 },
+        v.codePoints<string, 4>(4),
+        undefined
+      )
+    ).toStrictEqual({
+      type: 'string',
+      minLength: 4,
+      maxLength: 4,
+    });
+  });
+
+  test('should merge not code points restrictions', () => {
+    expect(
+      convertAction(
+        { type: 'string', not: { const: 'foo' } },
+        v.notCodePoints<string, 3>(3),
+        undefined
+      )
+    ).toStrictEqual({
+      type: 'string',
+      not: {
+        anyOf: [{ const: 'foo' }, { minLength: 3, maxLength: 3 }],
+      },
+    });
+  });
+
+  test('should throw error for code points actions with invalid type', () => {
+    const actions = [
+      v.codePoints<string, 3>(3),
+      v.maxCodePoints<string, 3>(3),
+      v.minCodePoints<string, 3>(3),
+      v.notCodePoints<string, 3>(3),
+    ];
+    for (const action of actions) {
+      const error = `The "${action.type}" action is not supported on type "undefined".`;
+      expect(() => convertAction({}, action, undefined)).toThrow(error);
+      expect(() => convertAction({}, action, { errorMode: 'throw' })).toThrow(
+        error
+      );
+    }
+  });
+
+  test('should warn error for code points actions with invalid type', () => {
+    const actions = [
+      [v.codePoints<string, 3>(3), { minLength: 3, maxLength: 3 }],
+      [v.maxCodePoints<string, 3>(3), { maxLength: 3 }],
+      [v.minCodePoints<string, 3>(3), { minLength: 3 }],
+      [v.notCodePoints<string, 3>(3), { not: { minLength: 3, maxLength: 3 } }],
+    ] as const;
+    for (const [action, expected] of actions) {
+      expect(convertAction({}, action, { errorMode: 'warn' })).toStrictEqual(
+        expected
+      );
+      expect(console.warn).toHaveBeenLastCalledWith(
+        `The "${action.type}" action is not supported on type "undefined".`
+      );
+    }
+  });
+
+  test('should ignore error for code points actions with invalid type', () => {
+    const actions = [
+      [v.codePoints<string, 3>(3), { minLength: 3, maxLength: 3 }],
+      [v.maxCodePoints<string, 3>(3), { maxLength: 3 }],
+      [v.minCodePoints<string, 3>(3), { minLength: 3 }],
+      [v.notCodePoints<string, 3>(3), { not: { minLength: 3, maxLength: 3 } }],
+    ] as const;
+    for (const [action, expected] of actions) {
+      expect(convertAction({}, action, { errorMode: 'ignore' })).toStrictEqual(
+        expected
+      );
+    }
+  });
+
   test('should convert length action for strings', () => {
     expect(
       convertAction(
@@ -1679,6 +1841,33 @@ describe('convertAction', () => {
             convertAction({ type }, action, { errorMode: 'ignore' })
           ).toStrictEqual({ type });
         }
+      }
+    }
+  });
+
+  test('should handle invalid code points requirements', () => {
+    for (const requirement of [-1, -0.5, 0.5, 1.5, NaN, Infinity, -Infinity]) {
+      const actions = [
+        v.codePoints<string, number>(requirement),
+        v.maxCodePoints<string, number>(requirement),
+        v.minCodePoints<string, number>(requirement),
+        v.notCodePoints<string, number>(requirement),
+      ];
+      for (const action of actions) {
+        const error = `The requirement of the "${action.type}" action must be a non-negative integer.`;
+        expect(() =>
+          convertAction({ type: 'string' }, action, undefined)
+        ).toThrow(error);
+        expect(() =>
+          convertAction({ type: 'string' }, action, { errorMode: 'throw' })
+        ).toThrow(error);
+        expect(
+          convertAction({ type: 'string' }, action, { errorMode: 'warn' })
+        ).toStrictEqual({ type: 'string' });
+        expect(console.warn).toHaveBeenLastCalledWith(error);
+        expect(
+          convertAction({ type: 'string' }, action, { errorMode: 'ignore' })
+        ).toStrictEqual({ type: 'string' });
       }
     }
   });

--- a/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
+++ b/packages/to-json-schema/src/converters/convertAction/convertAction.test.ts
@@ -789,9 +789,9 @@ describe('convertAction', () => {
 
   test('should warn error for code points actions with invalid type', () => {
     const actions = [
-      [v.codePoints<string, 3>(3), { minLength: 3, maxLength: 3 }],
-      [v.maxCodePoints<string, 3>(3), { maxLength: 3 }],
-      [v.minCodePoints<string, 3>(3), { minLength: 3 }],
+      [v.codePoints<string, 3>(3), {}],
+      [v.maxCodePoints<string, 3>(3), {}],
+      [v.minCodePoints<string, 3>(3), {}],
       [v.notCodePoints<string, 3>(3), {}],
     ] as const;
     for (const [action, expected] of actions) {
@@ -806,9 +806,9 @@ describe('convertAction', () => {
 
   test('should ignore error for code points actions with invalid type', () => {
     const actions = [
-      [v.codePoints<string, 3>(3), { minLength: 3, maxLength: 3 }],
-      [v.maxCodePoints<string, 3>(3), { maxLength: 3 }],
-      [v.minCodePoints<string, 3>(3), { minLength: 3 }],
+      [v.codePoints<string, 3>(3), {}],
+      [v.maxCodePoints<string, 3>(3), {}],
+      [v.minCodePoints<string, 3>(3), {}],
       [v.notCodePoints<string, 3>(3), {}],
     ] as const;
     for (const [action, expected] of actions) {

--- a/packages/to-json-schema/src/converters/convertAction/convertAction.ts
+++ b/packages/to-json-schema/src/converters/convertAction/convertAction.ts
@@ -889,6 +889,7 @@ export function convertAction(
           errors,
           `The "${valibotAction.type}" action is not supported on type "${jsonSchema.type}".`
         );
+        break;
       }
       jsonSchema.not = getNotRestriction(jsonSchema.not, {
         minLength: valibotAction.requirement,

--- a/packages/to-json-schema/src/converters/convertAction/convertAction.ts
+++ b/packages/to-json-schema/src/converters/convertAction/convertAction.ts
@@ -14,6 +14,11 @@ import {
 type Action =
   | v.Base64Action<string, v.ErrorMessage<v.Base64Issue<string>> | undefined>
   | v.BicAction<string, v.ErrorMessage<v.BicIssue<string>> | undefined>
+  | v.CodePointsAction<
+      string,
+      number,
+      v.ErrorMessage<v.CodePointsIssue<string, number>> | undefined
+    >
   | v.Cuid2Action<string, v.ErrorMessage<v.Cuid2Issue<string>> | undefined>
   | v.DecimalAction<string, v.ErrorMessage<v.DecimalIssue<string>> | undefined>
   | v.DescriptionAction<unknown, string>
@@ -92,6 +97,11 @@ type Action =
   | v.MacAction<string, v.ErrorMessage<v.MacIssue<string>> | undefined>
   | v.Mac48Action<string, v.ErrorMessage<v.Mac48Issue<string>> | undefined>
   | v.Mac64Action<string, v.ErrorMessage<v.Mac64Issue<string>> | undefined>
+  | v.MaxCodePointsAction<
+      string,
+      number,
+      v.ErrorMessage<v.MaxCodePointsIssue<string, number>> | undefined
+    >
   | v.MaxEntriesAction<
       v.EntriesInput,
       number,
@@ -108,6 +118,11 @@ type Action =
       v.ErrorMessage<v.MaxValueIssue<v.ValueInput, v.ValueInput>> | undefined
     >
   | v.MetadataAction<unknown, Record<string, unknown>>
+  | v.MinCodePointsAction<
+      string,
+      number,
+      v.ErrorMessage<v.MinCodePointsIssue<string, number>> | undefined
+    >
   | v.MinEntriesAction<
       v.EntriesInput,
       number,
@@ -132,6 +147,11 @@ type Action =
   | v.NonEmptyAction<
       v.LengthInput,
       v.ErrorMessage<v.NonEmptyIssue<v.LengthInput>> | undefined
+    >
+  | v.NotCodePointsAction<
+      string,
+      number,
+      v.ErrorMessage<v.NotCodePointsIssue<string, number>> | undefined
     >
   | v.NotValueAction<
       v.ValueInput,
@@ -338,6 +358,34 @@ export function convertAction(
       break;
     }
 
+    case 'code_points': {
+      if (
+        !Number.isInteger(valibotAction.requirement) ||
+        valibotAction.requirement < 0
+      ) {
+        errors = addError(
+          errors,
+          'The requirement of the "code_points" action must be a non-negative integer.'
+        );
+        break;
+      }
+      if (jsonSchema.type !== 'string') {
+        errors = addError(
+          errors,
+          `The "${valibotAction.type}" action is not supported on type "${jsonSchema.type}".`
+        );
+      }
+      jsonSchema.minLength = getLowerBound(
+        jsonSchema.minLength,
+        valibotAction.requirement
+      );
+      jsonSchema.maxLength = getUpperBound(
+        jsonSchema.maxLength,
+        valibotAction.requirement
+      );
+      break;
+    }
+
     case 'empty': {
       if (jsonSchema.type === 'array') {
         jsonSchema.maxItems = 0;
@@ -473,6 +521,9 @@ export function convertAction(
       break;
     }
 
+    // TODO(v2): Remove the legacy string conversion for length actions.
+    // Valibot counts UTF-16 code units, while JSON Schema counts Unicode code
+    // points. Use the codePoints actions for string schemas instead.
     case 'length': {
       if (
         !Number.isInteger(valibotAction.requirement) ||
@@ -499,6 +550,12 @@ export function convertAction(
             errors,
             `The "${valibotAction.type}" action is not supported on type "${jsonSchema.type}".`
           );
+        } else {
+          if (config?.errorMode === 'warn') {
+            console.warn(
+              'The "length" action is deprecated for string schemas because Valibot counts UTF-16 code units while JSON Schema counts Unicode code points. Use "codePoints" instead.'
+            );
+          }
         }
         jsonSchema.minLength = getLowerBound(
           jsonSchema.minLength,
@@ -559,6 +616,30 @@ export function convertAction(
       break;
     }
 
+    case 'max_code_points': {
+      if (
+        !Number.isInteger(valibotAction.requirement) ||
+        valibotAction.requirement < 0
+      ) {
+        errors = addError(
+          errors,
+          'The requirement of the "max_code_points" action must be a non-negative integer.'
+        );
+        break;
+      }
+      if (jsonSchema.type !== 'string') {
+        errors = addError(
+          errors,
+          `The "${valibotAction.type}" action is not supported on type "${jsonSchema.type}".`
+        );
+      }
+      jsonSchema.maxLength = getUpperBound(
+        jsonSchema.maxLength,
+        valibotAction.requirement
+      );
+      break;
+    }
+
     case 'max_length': {
       if (
         !Number.isInteger(valibotAction.requirement) ||
@@ -581,6 +662,12 @@ export function convertAction(
             errors,
             `The "${valibotAction.type}" action is not supported on type "${jsonSchema.type}".`
           );
+        } else {
+          if (config?.errorMode === 'warn') {
+            console.warn(
+              'The "maxLength" action is deprecated for string schemas because Valibot counts UTF-16 code units while JSON Schema counts Unicode code points. Use "maxCodePoints" instead.'
+            );
+          }
         }
         jsonSchema.maxLength = getUpperBound(
           jsonSchema.maxLength,
@@ -666,6 +753,30 @@ export function convertAction(
       break;
     }
 
+    case 'min_code_points': {
+      if (
+        !Number.isInteger(valibotAction.requirement) ||
+        valibotAction.requirement < 0
+      ) {
+        errors = addError(
+          errors,
+          'The requirement of the "min_code_points" action must be a non-negative integer.'
+        );
+        break;
+      }
+      if (jsonSchema.type !== 'string') {
+        errors = addError(
+          errors,
+          `The "${valibotAction.type}" action is not supported on type "${jsonSchema.type}".`
+        );
+      }
+      jsonSchema.minLength = getLowerBound(
+        jsonSchema.minLength,
+        valibotAction.requirement
+      );
+      break;
+    }
+
     case 'min_length': {
       if (
         !Number.isInteger(valibotAction.requirement) ||
@@ -688,6 +799,12 @@ export function convertAction(
             errors,
             `The "${valibotAction.type}" action is not supported on type "${jsonSchema.type}".`
           );
+        } else {
+          if (config?.errorMode === 'warn') {
+            console.warn(
+              'The "minLength" action is deprecated for string schemas because Valibot counts UTF-16 code units while JSON Schema counts Unicode code points. Use "minCodePoints" instead.'
+            );
+          }
         }
         jsonSchema.minLength = getLowerBound(
           jsonSchema.minLength,
@@ -753,6 +870,30 @@ export function convertAction(
           ? { enum: [valibotAction.requirement] }
           : { const: valibotAction.requirement }
       );
+      break;
+    }
+
+    case 'not_code_points': {
+      if (
+        !Number.isInteger(valibotAction.requirement) ||
+        valibotAction.requirement < 0
+      ) {
+        errors = addError(
+          errors,
+          'The requirement of the "not_code_points" action must be a non-negative integer.'
+        );
+        break;
+      }
+      if (jsonSchema.type !== 'string') {
+        errors = addError(
+          errors,
+          `The "${valibotAction.type}" action is not supported on type "${jsonSchema.type}".`
+        );
+      }
+      jsonSchema.not = getNotRestriction(jsonSchema.not, {
+        minLength: valibotAction.requirement,
+        maxLength: valibotAction.requirement,
+      });
       break;
     }
 

--- a/packages/to-json-schema/src/converters/convertAction/convertAction.ts
+++ b/packages/to-json-schema/src/converters/convertAction/convertAction.ts
@@ -374,6 +374,7 @@ export function convertAction(
           errors,
           `The "${valibotAction.type}" action is not supported on type "${jsonSchema.type}".`
         );
+        break;
       }
       jsonSchema.minLength = getLowerBound(
         jsonSchema.minLength,
@@ -632,6 +633,7 @@ export function convertAction(
           errors,
           `The "${valibotAction.type}" action is not supported on type "${jsonSchema.type}".`
         );
+        break;
       }
       jsonSchema.maxLength = getUpperBound(
         jsonSchema.maxLength,
@@ -769,6 +771,7 @@ export function convertAction(
           errors,
           `The "${valibotAction.type}" action is not supported on type "${jsonSchema.type}".`
         );
+        break;
       }
       jsonSchema.minLength = getLowerBound(
         jsonSchema.minLength,

--- a/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.test.ts
+++ b/packages/to-json-schema/src/functions/toJsonSchema/toJsonSchema.test.ts
@@ -15,6 +15,37 @@ describe('toJsonSchema', () => {
       });
     });
 
+    test('for code point actions', () => {
+      const actions = [
+        [v.codePoints(3), { minLength: 3, maxLength: 3 }],
+        [v.maxCodePoints(3), { maxLength: 3 }],
+        [v.minCodePoints(3), { minLength: 3 }],
+        [v.notCodePoints(3), { not: { minLength: 3, maxLength: 3 } }],
+      ] as const;
+      for (const [action, expected] of actions) {
+        expect(toJsonSchema(v.pipe(v.string(), action))).toStrictEqual({
+          $schema: 'http://json-schema.org/draft-07/schema#',
+          type: 'string',
+          ...expected,
+        });
+      }
+    });
+
+    test('warns for deprecated string length actions', () => {
+      expect(
+        toJsonSchema(v.pipe(v.string(), v.minLength(3)), {
+          errorMode: 'warn',
+        })
+      ).toStrictEqual({
+        $schema: 'http://json-schema.org/draft-07/schema#',
+        type: 'string',
+        minLength: 3,
+      });
+      expect(console.warn).toHaveBeenLastCalledWith(
+        'The "minLength" action is deprecated for string schemas because Valibot counts UTF-16 code units while JSON Schema counts Unicode code points. Use "minCodePoints" instead.'
+      );
+    });
+
     test('for complex schema with definitions', () => {
       const stringSchema = v.string();
       const complexSchema = v.pipe(


### PR DESCRIPTION
# Add code point string constraints to JSON Schema conversion

## Summary

- Add conversion support for `codePoints`, `minCodePoints`, `maxCodePoints`, and `notCodePoints`.
- Keep the existing string conversion for `length`, `minLength`, and `maxLength` for compatibility, while documenting it as deprecated and warning when `errorMode: 'warn'` is enabled.
- Preserve conversion of these legacy actions for arrays.
- Add test coverage and update the package README.

## Why `length` is not suitable for strings

For strings, Valibot uses JavaScript `value.length`, which counts UTF-16 code units. JSON Schema `minLength` and `maxLength` count Unicode code points. The same constraint can therefore validate differently after conversion.

For example:

~~~ts
const value = '😀';

value.length; // 2 UTF-16 code units
[...value].length; // 1 Unicode code point
~~~

`v.pipe(v.string(), v.length(1))` rejects `😀`, while its converted JSON Schema with `minLength: 1` and `maxLength: 1` accepts it. The `codePoints` actions use the same counting unit as JSON Schema and avoid this mismatch.

Combining marks and ZWJ sequences are another caveat: `é` consists of 2 code points, and `👩‍💻` of 3, even though each renders as one user-perceived character. `codePoints` aligns with JSON Schema, but validating user-perceived characters requires grapheme-cluster segmentation.

## Validation

- `pnpm -C packages/to-json-schema test`
- `pnpm -C packages/to-json-schema lint`
- `pnpm -C packages/to-json-schema format.check`

## Sources

1. [OpenAPI Specification 3.1.1, Schema Object](https://spec.openapis.org/oas/v3.1.1.html#schema-object) — the Schema Object is a superset of JSON Schema Draft 2020-12, and keyword definitions follow JSON Schema unless OpenAPI explicitly adds semantics.
2. [JSON Schema Validation Draft 2020-12, §6.3](https://json-schema.org/draft/2020-12/json-schema-validation#section-6.3) — the length used by minLength and maxLength is the number of characters defined by RFC 8259.
3. [RFC 8259, §1](https://www.rfc-editor.org/rfc/rfc8259#section-1) and [§7](https://www.rfc-editor.org/rfc/rfc8259#section-7) — JSON strings are sequences of Unicode characters, and non-BMP characters can be represented by escaped UTF-16 surrogate pairs.
4. [JSON Schema Test Suite: maxLength](https://github.com/json-schema-org/JSON-Schema-Test-Suite/blob/main/tests/draft2020-12/maxLength.json) — the official suite includes a valid maxLength: 2 case with two emoji represented by two surrogate pairs, demonstrating that JSON Schema counts them as two characters rather than four UTF-16 code units.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON Schema conversion support for code-point constraints, including minimum, maximum, exact, and excluded counts.
  * Preserved stricter existing bounds and combined exclusion restrictions during conversion.

* **Bug Fixes**
  * Improved handling of invalid code-point requirements and unsupported schema types across error modes.

* **Documentation**
  * Documented code-point actions and clarified the deprecation of string-based length conversions, while retaining array support.
  * Added warnings for deprecated string length actions when configured to warn.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->